### PR TITLE
Improve historical notes layout and paragraph splitting logic

### DIFF
--- a/docs/js/publication.js
+++ b/docs/js/publication.js
@@ -199,21 +199,26 @@
     }
 
     function buildHistoricalSection(notes) {
-        // Split into paragraphs if long
-        const paragraphs = notes.split(/\n\n|\. (?=[A-Z])/g).filter(p => p.trim());
+        // Split only on actual paragraph breaks (double newlines), not sentence boundaries
+        const paragraphs = notes.split(/\n\n+/).filter(p => p.trim());
+
+        // Use multi-column layout for longer text
+        const useColumns = notes.length > 500;
 
         return `
             <div class="animate-in delay-5">
                 <h2 class="font-mono text-xs text-accent uppercase tracking-widest mb-6 pb-2 border-b border-white/10">Historical Notes</h2>
                 <div class="prose prose-invert max-w-none">
-                    ${paragraphs.length > 1 ? `
+                    ${useColumns ? `
                         <div class="columns-1 md:columns-2 gap-8 column-rule space-y-4">
                             ${paragraphs.map((p, i) => `
-                                <p class="${i === 0 ? 'drop-cap' : ''} font-serif text-lg text-paper-200 leading-relaxed">${escapeHtml(p.trim())}${!p.trim().endsWith('.') ? '.' : ''}</p>
+                                <p class="${i === 0 ? 'drop-cap' : ''} font-serif text-lg text-paper-200 leading-relaxed">${escapeHtml(p.trim())}</p>
                             `).join('')}
                         </div>
                     ` : `
-                        <p class="drop-cap font-serif text-lg text-paper-200 leading-relaxed">${escapeHtml(notes)}</p>
+                        ${paragraphs.map((p, i) => `
+                            <p class="${i === 0 ? 'drop-cap' : ''} font-serif text-lg text-paper-200 leading-relaxed">${escapeHtml(p.trim())}</p>
+                        `).join('')}
                     `}
                 </div>
             </div>


### PR DESCRIPTION
## Summary
Refactored the historical notes section rendering to use more intelligent paragraph detection and improved layout handling for varying content lengths.

## Key Changes
- **Paragraph splitting**: Changed from splitting on both double newlines AND sentence boundaries (regex: `/\n\n|\. (?=[A-Z])/g`) to only splitting on actual paragraph breaks (regex: `/\n\n+/`). This prevents unintended fragmentation of sentences within paragraphs.
- **Layout logic**: Replaced paragraph count-based condition with content length-based condition (`notes.length > 500`). Multi-column layout now activates for longer text rather than whenever there are multiple paragraphs.
- **Consistent paragraph handling**: Updated the single-column fallback to properly map and render all paragraphs instead of treating the entire notes string as one block, ensuring consistent formatting regardless of layout mode.
- **Removed auto-punctuation**: Eliminated the logic that automatically appended periods to paragraphs that didn't end with one, allowing content to be rendered as-is.

## Implementation Details
- The change maintains the drop-cap styling on the first paragraph in both layout modes
- Multi-column layout is now triggered by content length (>500 characters) rather than paragraph count, providing better UX for varying content sizes
- All paragraphs are now consistently processed through the same mapping function, improving code maintainability

https://claude.ai/code/session_01L8145LGNPQx7rS65zWRxUy