### PR TITLE
Remove 'Key initiatives' section from About page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -535,15 +535,6 @@
                         <p>This project highlights major publications, influential editors, and the themes that defined coverage — civil rights reporting, local news, political engagement, and cultural arts — while also reflecting on the policy landscape that has shaped Black-owned media, from historic barriers to today’s digital and regulatory challenges.</p>
                         <p>By preserving these archives and stories, the database underscores the Black Press’s enduring role in informing and empowering New Jersey’s Black communities, and it supports ongoing efforts to sustain this vital media legacy.</p>
 
-                        <div>
-                            <h4 class="font-sans text-sm font-bold text-white mb-2 uppercase tracking-wide">Key initiatives</h4>
-                            <p class="text-base mb-4">
-                                Beyond archiving, this project supports the <a href="https://centerforcooperativemedia.org/programs/black-publishers-collective/" target="_blank" rel="noopener" class="text-accent hover:text-white transition-colors underline underline-offset-2">Black Publishers Collective (BPC)</a>, a network fostering collaboration and sustainability among Black media creators.
-                            </p>
-                            <p class="text-base">
-                                It also aligns with the <a href="https://sjiep.org" target="_blank" rel="noopener" class="text-accent hover:text-white transition-colors underline underline-offset-2">South Jersey Information Equity Project (SJIEP)</a>, which trains aspiring community reporters to enhance local news coverage and civic resilience in underserved areas.
-                            </p>
-                        </div>
                     </div>
                 </div>
 


### PR DESCRIPTION
### Motivation
- Remove the outreach/initiative copy from the About section of the NJ Black Press Database, specifically the Black Publishers Collective (BPC) and South Jersey Information Equity Project (SJIEP) paragraphs.

### Description
- Delete the "Key initiatives" block from `docs/index.html` in the About/footer area, removing the two paragraphs and their links for BPC and SJIEP.

### Testing
- Ran `rg -n "Black Publishers Collective|South Jersey Information Equity Project" docs/index.html` (no matches), inspected `git diff -- docs/index.html` to confirm only the targeted block was removed, and ran `git status --short` to confirm a clean working tree after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c180cf34b0832495b7018cadc97953)