### PR TITLE
Make Woven easier to understand and use

### DIFF
--- a/data/test_woven_usability.py
+++ b/data/test_woven_usability.py
@@ -9,6 +9,8 @@ ROOT = Path(__file__).resolve().parent.parent
 HTML_PATH = ROOT / "docs" / "woven.html"
 CSS_PATH = ROOT / "docs" / "css" / "woven-guide.css"
 JS_PATH = ROOT / "docs" / "js" / "woven" / "guide.js"
+DIALOG_PATH = ROOT / "docs" / "js" / "woven" / "guide-dialog.js"
+STAGE_PATH = ROOT / "docs" / "js" / "woven" / "guide-stage.js"
 
 
 class WovenParser(HTMLParser):
@@ -32,6 +34,8 @@ def main() -> None:
     html = HTML_PATH.read_text(encoding="utf-8")
     css = CSS_PATH.read_text(encoding="utf-8")
     js = JS_PATH.read_text(encoding="utf-8")
+    dialog_js = DIALOG_PATH.read_text(encoding="utf-8")
+    stage_js = STAGE_PATH.read_text(encoding="utf-8")
     parser = WovenParser()
     parser.feed(html)
 
@@ -71,6 +75,7 @@ def main() -> None:
     assert "Previous era" in html and "Next era" in html and "Whole timeline" in html
 
     assert "sessionStorage" in js
+    assert "createStartDialog" in js and "createStageCoordinator" in js
     assert "stopImmediatePropagation" in js
     assert "fetch('data/publications.json')" in js
     assert "window.njbpWoven?.open" in js
@@ -78,6 +83,15 @@ def main() -> None:
     assert "woven-mobile-tour" in js
     assert "woven-story-expanded" in js
     assert "Read story" in js and "More loom" in js
+    assert "closeSearchResults(true)" in js
+
+    assert "aria-modal" in dialog_js
+    assert "document.addEventListener('keydown', containFocus, true)" in dialog_js
+    assert "event.key !== 'Tab' || !media.matches" in dialog_js
+    assert "window.njbpWoven?.exit?.()" in stage_js
+    assert "woven-help-card" in stage_js and "woven-tourpicker" in stage_js
+    assert "MutationObserver(refreshChrome)" in stage_js
+    assert "app?.labels?.update" in stage_js
 
     assert "#woven-search-results" in css
     assert "#woven-start-card" in css
@@ -87,6 +101,8 @@ def main() -> None:
 
     assert len(css.splitlines()) <= 400, "split the guidance stylesheet before it exceeds 400 lines"
     assert len(js.splitlines()) <= 400, "split the guidance module before it exceeds 400 lines"
+    assert len(dialog_js.splitlines()) <= 400
+    assert len(stage_js.splitlines()) <= 400
     print("PASS: Woven has guided entry, explicit search, progressive tools, and mobile story balance")
 
 

--- a/data/test_woven_usability.py
+++ b/data/test_woven_usability.py
@@ -1,0 +1,94 @@
+"""Regression checks for Woven's first-visit guidance and explicit controls."""
+
+from collections import Counter
+from html.parser import HTMLParser
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+HTML_PATH = ROOT / "docs" / "woven.html"
+CSS_PATH = ROOT / "docs" / "css" / "woven-guide.css"
+JS_PATH = ROOT / "docs" / "js" / "woven" / "guide.js"
+
+
+class WovenParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.ids: list[str] = []
+        self.scripts: list[str] = []
+        self.stylesheets: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        values = dict(attrs)
+        if values.get("id"):
+            self.ids.append(values["id"] or "")
+        if tag == "script" and values.get("src"):
+            self.scripts.append(values["src"] or "")
+        if tag == "link" and values.get("rel") == "stylesheet" and values.get("href"):
+            self.stylesheets.append(values["href"] or "")
+
+
+def main() -> None:
+    html = HTML_PATH.read_text(encoding="utf-8")
+    css = CSS_PATH.read_text(encoding="utf-8")
+    js = JS_PATH.read_text(encoding="utf-8")
+    parser = WovenParser()
+    parser.feed(html)
+
+    duplicates = [element_id for element_id, count in Counter(parser.ids).items() if count > 1]
+    assert not duplicates, f"duplicate element IDs: {duplicates}"
+
+    required_ids = {
+        "btn-start",
+        "btn-tours",
+        "btn-help",
+        "btn-ghost",
+        "btn-reset",
+        "btn-fullscreen",
+        "woven-more-tools",
+        "woven-search",
+        "woven-search-results",
+        "woven-start-card",
+        "woven-coach",
+        "woven-tourbar",
+    }
+    assert required_ids.issubset(parser.ids), required_ids - set(parser.ids)
+    assert "css/woven-guide.css" in parser.stylesheets
+    assert "js/woven/guide.js" in parser.scripts
+    assert parser.scripts.index("js/woven/guide.js") < parser.scripts.index("js/woven/main.js")
+
+    details_start = html.index('<details id="woven-more-tools">')
+    details_end = html.index("</details>", details_start)
+    for control_id in ("btn-help", "btn-ghost", "btn-reset", "btn-fullscreen"):
+        position = html.index(f'id="{control_id}"')
+        assert details_start < position < details_end, f"{control_id} must stay under More tools"
+
+    assert html.count('data-guide-action="story"') == 1
+    assert html.count('data-guide-action="search"') == 1
+    assert html.count('data-guide-action="explore"') == 1
+    assert 'role="combobox"' in html
+    assert 'role="listbox"' in html
+    assert "Previous era" in html and "Next era" in html and "Whole timeline" in html
+
+    assert "sessionStorage" in js
+    assert "stopImmediatePropagation" in js
+    assert "fetch('data/publications.json')" in js
+    assert "window.njbpWoven?.open" in js
+    assert "aria-activedescendant" in js
+    assert "woven-mobile-tour" in js
+    assert "woven-story-expanded" in js
+    assert "Read story" in js and "More loom" in js
+
+    assert "#woven-search-results" in css
+    assert "#woven-start-card" in css
+    assert "#woven-more-tools" in css
+    assert "body.woven-mobile-tour:not(.woven-story-expanded) #woven-card" in css
+    assert "[data-guide-story-toggle]" in css
+
+    assert len(css.splitlines()) <= 400, "split the guidance stylesheet before it exceeds 400 lines"
+    assert len(js.splitlines()) <= 400, "split the guidance module before it exceeds 400 lines"
+    print("PASS: Woven has guided entry, explicit search, progressive tools, and mobile story balance")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/css/woven-guide.css
+++ b/docs/css/woven-guide.css
@@ -1,0 +1,390 @@
+/* Woven — first-visit guidance and progressive disclosure.
+   This layer changes the interface around the loom, not the archive drawing. */
+/* ---------- a clearer introduction ---------- */
+#woven-intro .intro-grid { align-items: start; }
+.woven-intro-kicker,
+.woven-guide-kicker {
+  margin: 0 0 0.45rem;
+  font-family: var(--mono);
+  font-size: 10px;
+  line-height: 1.4;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--stain-light);
+}
+.woven-intro-copy { max-width: 52ch; }
+.woven-intro-copy p { margin: 0; }
+.woven-intro-lede {
+  font-size: 1rem;
+  line-height: 1.55;
+  color: var(--linen-100);
+}
+.woven-intro-detail {
+  margin-top: 0.45rem !important;
+  font-size: 0.82rem;
+  line-height: 1.5;
+  color: var(--linen-300);
+}
+.woven-intro-prompt {
+  margin-top: 0.55rem !important;
+  font-family: var(--mono);
+  font-size: 11px;
+  line-height: 1.45;
+  color: var(--linen-200);
+}
+/* ---------- the primary toolbar ---------- */
+#woven-topbar { align-items: center; gap: 0.65rem; }
+.woven-primary-actions {
+  display: flex;
+  flex: 0 0 auto;
+  gap: 0.5rem;
+  align-items: center;
+}
+.woven-primary-btn {
+  border-color: var(--oak-500);
+  color: var(--linen-50);
+}
+#btn-start { background: var(--walnut-700); }
+#btn-tours { color: var(--stain-light); }
+#woven-searchform {
+  position: relative;
+  display: block;
+  flex: 1 1 23rem;
+  max-width: 34rem;
+  min-width: 13rem;
+}
+.woven-search-row { display: flex; align-items: stretch; }
+#woven-search {
+  flex: 1 1 auto;
+  width: auto;
+  min-width: 0;
+  min-height: 2.2rem;
+  border-right: 0;
+}
+.woven-search-submit {
+  flex: 0 0 auto;
+  min-height: 2.2rem;
+  padding-inline: 0.75rem;
+  border-color: var(--oak-500);
+}
+#woven-search-count {
+  display: block;
+  margin-top: 0.25rem;
+  line-height: 1.35;
+}
+#woven-search-count:empty { display: none; }
+#woven-search-results {
+  position: absolute;
+  top: calc(100% + 0.35rem);
+  left: 0;
+  right: 0;
+  z-index: 30;
+  max-height: min(25rem, 62vh);
+  overflow-y: auto;
+  background: var(--walnut-800);
+  border: 1px solid var(--oak-500);
+}
+#woven-search-results[hidden] { display: none; }
+.woven-search-option {
+  display: block;
+  width: 100%;
+  padding: 0.7rem 0.8rem;
+  text-align: left;
+  background: transparent;
+  border: 0;
+  border-bottom: 1px solid var(--walnut-600);
+  color: var(--linen-100);
+  cursor: pointer;
+}
+.woven-search-option:last-of-type { border-bottom: 0; }
+.woven-search-option:hover,
+.woven-search-option[aria-selected="true"] {
+  background: var(--walnut-700);
+  border-left: 3px solid var(--stain);
+  padding-left: calc(0.8rem - 3px);
+}
+.woven-search-option:focus-visible {
+  outline: 2px solid var(--stain);
+  outline-offset: -3px;
+}
+.woven-result-name {
+  display: block;
+  font-weight: 700;
+  color: var(--linen-50);
+}
+.woven-result-meta {
+  display: block;
+  margin-top: 0.15rem;
+  font-family: var(--mono);
+  font-size: 10px;
+  line-height: 1.4;
+  color: var(--linen-300);
+}
+.woven-search-overflow {
+  padding: 0.55rem 0.8rem;
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--linen-300);
+  border-top: 1px solid var(--walnut-600);
+}
+#woven-more-tools {
+  position: relative;
+  flex: 0 0 auto;
+  margin-left: auto;
+}
+#woven-more-tools summary { list-style: none; white-space: nowrap; }
+#woven-more-tools summary::-webkit-details-marker { display: none; }
+#woven-more-tools summary::before {
+  content: '+ ';
+  color: var(--stain-light);
+}
+#woven-more-tools[open] summary::before { content: '− '; }
+.woven-more-panel {
+  position: absolute;
+  top: calc(100% + 0.4rem);
+  right: 0;
+  z-index: 29;
+  display: grid;
+  gap: 0.4rem;
+  width: 18rem;
+  padding: 0.65rem;
+  background: var(--walnut-800);
+  border: 1px solid var(--oak-500);
+}
+.woven-more-panel .woven-btn { width: 100%; text-align: left; }
+/* ---------- first-visit chooser ---------- */
+#woven-start-card {
+  position: absolute;
+  top: var(--woven-chrome-h, 5.5rem);
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 12;
+  display: flex;
+  align-items: safe center;
+  justify-content: center;
+  padding: 1rem;
+  overflow-y: auto;
+  background: rgba(11, 8, 6, 0.91);
+}
+#woven-start-card[hidden] { display: none; }
+.woven-guide-inner {
+  width: min(58rem, 100%);
+  max-height: 100%;
+  overflow-y: auto;
+  background: var(--walnut-800);
+  border: 1px solid var(--oak-500);
+}
+.woven-guide-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.2rem;
+  border-bottom: 1px solid var(--walnut-600);
+}
+.woven-guide-head h2 {
+  font-family: 'Libre Franklin', Arial, sans-serif;
+  font-size: clamp(1.35rem, 3vw, 2rem);
+  font-weight: 800;
+  line-height: 1.1;
+  color: var(--linen-50);
+}
+.woven-guide-body { padding: 1rem 1.2rem 1.2rem; }
+.woven-guide-body > p {
+  max-width: 64ch;
+  line-height: 1.55;
+  color: var(--linen-200);
+}
+.woven-start-actions {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.7rem;
+  margin-top: 1rem;
+}
+.woven-guide-action {
+  min-height: 9rem;
+  padding: 1rem;
+  text-align: left;
+  background: var(--walnut-700);
+  border: 1px solid var(--walnut-600);
+  color: inherit;
+  cursor: pointer;
+}
+.woven-guide-action:hover { border-color: var(--stain); }
+.woven-guide-action:focus-visible {
+  outline: 2px solid var(--stain);
+  outline-offset: 2px;
+}
+.woven-guide-action-title {
+  display: block;
+  font-family: 'Libre Franklin', Arial, sans-serif;
+  font-size: 1.05rem;
+  font-weight: 700;
+  line-height: 1.25;
+  color: var(--linen-50);
+}
+.woven-guide-action-copy {
+  display: block;
+  margin-top: 0.45rem;
+  font-size: 0.86rem;
+  line-height: 1.5;
+  color: var(--linen-300);
+}
+.woven-quick-guide {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  margin-top: 1rem;
+  padding-top: 0.8rem;
+  border-top: 1px solid var(--walnut-600);
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--linen-300);
+}
+.woven-quick-guide b {
+  display: inline-grid;
+  width: 1.35rem;
+  height: 1.35rem;
+  place-items: center;
+  margin-right: 0.25rem;
+  border: 1px solid var(--oak-500);
+  color: var(--linen-50);
+}
+.woven-guide-list-link { margin-top: 0.9rem; font-size: 0.85rem; }
+/* ---------- lightweight in-canvas coaching ---------- */
+#woven-coach {
+  position: absolute;
+  left: 0.75rem;
+  bottom: calc(var(--woven-rail-h, 2.2rem) + 0.65rem);
+  z-index: 8;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  max-width: min(38rem, calc(100% - 1.5rem));
+  padding: 0.55rem 0.7rem;
+  background: var(--walnut-700);
+  border: 1px solid var(--oak-500);
+  font-family: var(--mono);
+  font-size: 10px;
+  line-height: 1.4;
+  color: var(--linen-200);
+}
+#woven-coach[hidden] { display: none; }
+#woven-coach strong { color: var(--linen-50); }
+#woven-coach button {
+  flex: 0 0 auto;
+  padding: 0.25rem 0.45rem;
+  background: transparent;
+  border: 1px solid var(--walnut-600);
+  color: var(--linen-100);
+  cursor: pointer;
+}
+#woven-coach button:focus-visible { outline: 2px solid var(--stain); }
+/* The docked key starts with the answer, then the visual distinctions. */
+#woven-legend .lg-title {
+  margin-bottom: 0.45rem;
+  font-family: 'Libre Franklin', Arial, sans-serif;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--linen-50);
+}
+#woven-legend .lg-cta { width: 100%; margin-top: 0.75rem; }
+/* ---------- small-screen story balance ---------- */
+@media (max-width: 700px) {
+  #woven-topbar {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+  }
+  .woven-primary-actions {
+    grid-column: 1 / -1;
+    min-width: 0;
+    overflow-x: auto;
+    padding-bottom: 3px;
+    scrollbar-width: thin;
+  }
+  #woven-searchform { grid-column: 1; width: 100%; max-width: none; min-width: 0; }
+  #woven-more-tools { grid-column: 2; margin-left: 0; }
+  .woven-more-panel { width: min(19rem, calc(100vw - 1.2rem)); }
+  .woven-search-submit { padding-inline: 0.6rem; }
+  #woven-search-results { max-height: 50vh; }
+  #woven-start-card {
+    position: fixed;
+    inset: 0;
+    z-index: 70;
+    padding: 0.75rem;
+  }
+  body.woven-guide-open { overflow: hidden; }
+  .woven-guide-inner { max-height: 100%; }
+  .woven-start-actions { grid-template-columns: 1fr; }
+  .woven-guide-action { min-height: 0; }
+  .woven-quick-guide { display: grid; }
+  #woven-coach {
+    right: 0.6rem;
+    left: 0.6rem;
+    max-width: none;
+  }
+  body.woven-mobile-tour #woven-tourbar [data-guide-story-toggle] {
+    order: -2;
+    border-color: var(--stain);
+    color: var(--linen-50);
+  }
+  body.woven-mobile-tour:not(.woven-story-expanded) #woven-card:not([hidden]) {
+    max-width: min(22rem, calc(100% - 1.2rem));
+    max-height: 9.5rem;
+    padding: 0.65rem 0.7rem;
+  }
+  body.woven-mobile-tour:not(.woven-story-expanded) #woven-card .card-body {
+    overflow: hidden;
+    scrollbar-width: none;
+  }
+  body.woven-mobile-tour:not(.woven-story-expanded) #woven-card .card-body::-webkit-scrollbar {
+    display: none;
+  }
+  body.woven-mobile-tour:not(.woven-story-expanded) #woven-card h3 {
+    display: -webkit-box;
+    overflow: hidden;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    font-size: 17px;
+  }
+  body.woven-mobile-tour:not(.woven-story-expanded) #woven-card .card-body > p {
+    display: none;
+  }
+  body.woven-mobile-tour:not(.woven-story-expanded) #woven-card .card-body > p:first-of-type {
+    display: -webkit-box;
+    overflow: hidden;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    margin-top: 0.35rem;
+    font-size: 13px;
+    line-height: 1.4;
+  }
+  body.woven-mobile-tour:not(.woven-story-expanded) #woven-card .card-body > p.band,
+  body.woven-mobile-tour:not(.woven-story-expanded) #woven-card .card-body > p.flag {
+    display: block;
+    overflow: hidden;
+    margin-top: 0.3rem;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+  body.woven-mobile-tour:not(.woven-story-expanded) #woven-card .card-more {
+    display: none !important;
+  }
+}
+@media (max-width: 430px) {
+  .woven-primary-actions { gap: 0.35rem; }
+  .woven-primary-actions .woven-btn { padding-inline: 0.6rem; }
+  .woven-search-submit { font-size: 0; }
+  .woven-search-submit::before { content: 'Go'; font-size: 11px; }
+  .woven-guide-head, .woven-guide-body { padding-inline: 0.9rem; }
+}
+@media (prefers-contrast: more), (forced-colors: active) {
+  #woven-start-card,
+  #woven-search-results,
+  .woven-more-panel { background: Canvas; border-color: CanvasText; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .woven-guide-action { scroll-behavior: auto; }
+}

--- a/docs/js/woven/guide-dialog.js
+++ b/docs/js/woven/guide-dialog.js
@@ -1,0 +1,72 @@
+// Woven — responsive first-visit dialog behavior.
+const FOCUSABLE = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])'
+].join(',');
+
+export function createStartDialog({ dialog, trigger, media, beforeOpen, afterClose }) {
+  function focusables() {
+    return dialog ? Array.from(dialog.querySelectorAll(FOCUSABLE)).filter((el) => !el.hidden) : [];
+  }
+
+  function syncModality() {
+    if (!dialog) return;
+    dialog.setAttribute('aria-modal', String(!dialog.hidden && media.matches));
+  }
+
+  function open() {
+    if (!dialog || !dialog.hidden) return false;
+    beforeOpen?.();
+    dialog.hidden = false;
+    document.body.classList.add('woven-guide-open');
+    syncModality();
+    requestAnimationFrame(() => {
+      const preferred = dialog.querySelector('[data-guide-action]');
+      (preferred || focusables()[0])?.focus({ preventScroll: true });
+    });
+    return true;
+  }
+
+  function close(options = {}) {
+    if (!dialog || dialog.hidden) return false;
+    dialog.hidden = true;
+    document.body.classList.remove('woven-guide-open');
+    syncModality();
+    afterClose?.(options);
+    if (options.restoreFocus !== false) trigger?.focus({ preventScroll: true });
+    return true;
+  }
+
+  function containFocus(event) {
+    if (!dialog || dialog.hidden) return;
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      close();
+      return;
+    }
+    if (event.key !== 'Tab' || !media.matches) return;
+    const nodes = focusables();
+    if (!nodes.length) return;
+    const first = nodes[0];
+    const last = nodes[nodes.length - 1];
+    const active = document.activeElement;
+    if (!dialog.contains(active) || (!event.shiftKey && active === last) || (event.shiftKey && active === first)) {
+      event.preventDefault();
+      (event.shiftKey ? last : first).focus({ preventScroll: true });
+    }
+  }
+
+  dialog?.addEventListener('click', (event) => {
+    if (event.target === dialog) close();
+  });
+  document.addEventListener('keydown', containFocus, true);
+  media.addEventListener('change', syncModality);
+  syncModality();
+
+  return { open, close };
+}

--- a/docs/js/woven/guide-stage.js
+++ b/docs/js/woven/guide-stage.js
@@ -1,0 +1,38 @@
+// Woven — coordinate guidance with the existing stage overlays and measurements.
+export function createStageCoordinator({ tourbar, toursButton, moreTools, searchCount }) {
+  function closeOverlays() {
+    const interactiveOpen = ['woven-panel', 'woven-card', 'woven-ghostnames']
+      .some((id) => document.getElementById(id) && !document.getElementById(id).hidden) ||
+      (tourbar && !tourbar.hidden);
+    if (interactiveOpen) window.njbpWoven?.exit?.();
+    for (const id of ['woven-help-card', 'woven-tourpicker', 'woven-ghostcard']) {
+      const overlay = document.getElementById(id);
+      if (overlay) overlay.hidden = true;
+    }
+    toursButton?.setAttribute('aria-expanded', 'false');
+  }
+
+  let refreshFrame = 0;
+  function refreshChrome() {
+    if (refreshFrame) return;
+    refreshFrame = requestAnimationFrame(() => {
+      refreshFrame = 0;
+      const app = window.__woven?.app;
+      if (app?.labels?.update) app.labels.update();
+      else app?.measureChrome?.();
+      if (app) app.needsRender = true;
+    });
+  }
+
+  if (searchCount) {
+    const observer = new MutationObserver(refreshChrome);
+    observer.observe(searchCount, { childList: true, characterData: true, subtree: true });
+  }
+
+  function prepareSearch() {
+    closeOverlays();
+    if (moreTools) moreTools.open = false;
+  }
+
+  return { closeOverlays, prepareSearch, refreshChrome };
+}

--- a/docs/js/woven/guide.js
+++ b/docs/js/woven/guide.js
@@ -1,3 +1,6 @@
+import { createStartDialog } from './guide-dialog.js';
+import { createStageCoordinator } from './guide-stage.js';
+
 // Woven — first-visit guidance, explicit search results, and mobile story balance.
 const stage = document.getElementById('woven-stage');
 const canvas = document.getElementById('woven-canvas');
@@ -27,34 +30,26 @@ function readSession(key) {
 function writeSession(key) {
   try { sessionStorage.setItem(key, '1'); } catch { /* storage can be blocked */ }
 }
-function openStartCard() {
-  if (!startCard || !startCard.hidden) return;
-  if (moreTools) moreTools.open = false;
-  closeSearchResults();
-  hideCoach(false);
-  startCard.hidden = false;
-  document.body.classList.add('woven-guide-open');
-  requestAnimationFrame(() => startCard.querySelector('[data-guide-action]')?.focus({ preventScroll: true }));
-}
-function closeStartCard({ showCoach = true, restoreFocus = true } = {}) {
-  if (!startCard || startCard.hidden) return;
-  startCard.hidden = true;
-  document.body.classList.remove('woven-guide-open');
-  writeSession(START_KEY);
-  if (showCoach) maybeShowCoach();
-  if (restoreFocus) startButton?.focus({ preventScroll: true });
-}
+const stageCoordinator = createStageCoordinator({ tourbar, toursButton, moreTools, searchCount });
+const startDialog = createStartDialog({
+  dialog: startCard,
+  trigger: startButton,
+  media: narrow,
+  beforeOpen: () => {
+    stageCoordinator.closeOverlays();
+    if (moreTools) moreTools.open = false;
+    closeSearchResults(true);
+    hideCoach(false);
+  },
+  afterClose: ({ showCoach = true } = {}) => {
+    writeSession(START_KEY);
+    if (showCoach) maybeShowCoach();
+  }
+});
+function openStartCard() { startDialog.open(); }
+function closeStartCard(options = {}) { startDialog.close(options); }
 startButton?.addEventListener('click', openStartCard);
 startCard?.querySelector('[data-guide-close]')?.addEventListener('click', () => closeStartCard());
-startCard?.addEventListener('click', (event) => {
-  if (event.target === startCard) closeStartCard();
-});
-startCard?.addEventListener('keydown', (event) => {
-  if (event.key !== 'Escape') return;
-  event.preventDefault();
-  event.stopPropagation();
-  closeStartCard();
-});
 startCard?.querySelectorAll('[data-guide-action]').forEach((button) => {
   button.addEventListener('click', () => {
     const action = button.dataset.guideAction;
@@ -181,6 +176,7 @@ function renderSearchResults() {
     closeSearchResults(false);
     return;
   }
+  stageCoordinator.prepareSearch();
   if (recordsFailed) {
     closeSearchResults(false);
     searchCount.textContent = 'Search is unavailable. Open the full archive instead.';
@@ -282,6 +278,9 @@ function openRecordWhenReady(id, name, attempt) {
   }
   location.assign(`${location.pathname}?pub=${encodeURIComponent(id)}`);
 }
+searchInput?.addEventListener('focus', () => {
+  if ((searchInput.value || '').trim().length >= 2) renderSearchResults();
+});
 searchInput?.addEventListener('input', (event) => {
   event.stopImmediatePropagation();
   renderSearchResults();
@@ -324,7 +323,7 @@ searchResults?.addEventListener('click', (event) => {
   if (option) chooseResult(matches[Number(option.dataset.resultIndex)]);
 });
 document.addEventListener('pointerdown', (event) => {
-  if (searchForm && !searchForm.contains(event.target)) closeSearchResults();
+  if (searchForm && !searchForm.contains(event.target)) closeSearchResults(true);
   if (moreTools?.open && !moreTools.contains(event.target)) moreTools.open = false;
 });
 document.getElementById('btn-reset')?.addEventListener('click', () => {

--- a/docs/js/woven/guide.js
+++ b/docs/js/woven/guide.js
@@ -1,0 +1,397 @@
+// Woven — first-visit guidance, explicit search results, and mobile story balance.
+const stage = document.getElementById('woven-stage');
+const canvas = document.getElementById('woven-canvas');
+const startCard = document.getElementById('woven-start-card');
+const startButton = document.getElementById('btn-start');
+const toursButton = document.getElementById('btn-tours');
+const searchForm = document.getElementById('woven-searchform');
+const searchInput = document.getElementById('woven-search');
+const searchCount = document.getElementById('woven-search-count');
+const searchResults = document.getElementById('woven-search-results');
+const moreTools = document.getElementById('woven-more-tools');
+const coach = document.getElementById('woven-coach');
+const tourbar = document.getElementById('woven-tourbar');
+const params = new URLSearchParams(location.search);
+const narrow = window.matchMedia('(max-width: 700px)');
+const START_KEY = 'njbp.woven.start.v2';
+const COACH_KEY = 'njbp.woven.coach.v2';
+const hasDeepLink = ['pub', 'story', 'ghost', 'nogl', 'twin'].some((key) => params.has(key));
+let records = [];
+let recordsReady = false;
+let recordsFailed = false;
+let matches = [];
+let activeResult = -1;
+function readSession(key) {
+  try { return sessionStorage.getItem(key) === '1'; } catch { return false; }
+}
+function writeSession(key) {
+  try { sessionStorage.setItem(key, '1'); } catch { /* storage can be blocked */ }
+}
+function openStartCard() {
+  if (!startCard || !startCard.hidden) return;
+  if (moreTools) moreTools.open = false;
+  closeSearchResults();
+  hideCoach(false);
+  startCard.hidden = false;
+  document.body.classList.add('woven-guide-open');
+  requestAnimationFrame(() => startCard.querySelector('[data-guide-action]')?.focus({ preventScroll: true }));
+}
+function closeStartCard({ showCoach = true, restoreFocus = true } = {}) {
+  if (!startCard || startCard.hidden) return;
+  startCard.hidden = true;
+  document.body.classList.remove('woven-guide-open');
+  writeSession(START_KEY);
+  if (showCoach) maybeShowCoach();
+  if (restoreFocus) startButton?.focus({ preventScroll: true });
+}
+startButton?.addEventListener('click', openStartCard);
+startCard?.querySelector('[data-guide-close]')?.addEventListener('click', () => closeStartCard());
+startCard?.addEventListener('click', (event) => {
+  if (event.target === startCard) closeStartCard();
+});
+startCard?.addEventListener('keydown', (event) => {
+  if (event.key !== 'Escape') return;
+  event.preventDefault();
+  event.stopPropagation();
+  closeStartCard();
+});
+startCard?.querySelectorAll('[data-guide-action]').forEach((button) => {
+  button.addEventListener('click', () => {
+    const action = button.dataset.guideAction;
+    closeStartCard({ showCoach: action === 'explore', restoreFocus: false });
+    if (action === 'story') {
+      hideCoach(false);
+      requestAnimationFrame(() => toursButton?.click());
+    } else if (action === 'search') {
+      hideCoach(false);
+      searchInput?.focus({ preventScroll: true });
+      if (searchCount) searchCount.textContent = 'Type at least 2 letters, then choose a result.';
+    } else {
+      canvas?.focus({ preventScroll: true });
+    }
+  });
+});
+function maybeShowCoach() {
+  if (!coach || readSession(COACH_KEY) || !startCard?.hidden || hasDeepLink) return;
+  if (tourbar && !tourbar.hidden) return;
+  coach.hidden = false;
+}
+function hideCoach(remember = true) {
+  if (!coach) return;
+  coach.hidden = true;
+  if (remember) writeSession(COACH_KEY);
+}
+coach?.querySelector('button')?.addEventListener('click', () => hideCoach());
+canvas?.addEventListener('pointerdown', () => hideCoach(), { passive: true });
+canvas?.addEventListener('wheel', () => hideCoach(), { passive: true });
+canvas?.addEventListener('keydown', (event) => {
+  if (/^(Arrow|Page|Home|End|Enter| |\+|-|0)/.test(event.key)) hideCoach();
+});
+toursButton?.addEventListener('click', () => {
+  hideCoach(false);
+  requestAnimationFrame(enhanceTourPicker);
+});
+document.getElementById('btn-ghost')?.addEventListener('click', () => hideCoach(false));
+function enhanceTourPicker() {
+  const picker = document.getElementById('woven-tourpicker');
+  if (!picker || picker.hidden) return;
+  const heading = picker.querySelector('h3');
+  const intro = picker.querySelector('.card-scroll > p');
+  if (heading) heading.textContent = 'Guided stories';
+  if (intro) intro.textContent = 'Choose a story to follow documented events and evidence across the timeline.';
+  picker.querySelectorAll('[data-play]').forEach((button) => { button.textContent = 'Start this story'; });
+}
+let loomReadyHandled = false;
+function handleLoomReady() {
+  if (loomReadyHandled) return;
+  const legend = document.getElementById('woven-legend');
+  if (!legend) return;
+  loomReadyHandled = true;
+  enhanceLegend(legend);
+  if (!hasDeepLink && !readSession(START_KEY)) openStartCard();
+  else if (!hasDeepLink) maybeShowCoach();
+}
+function enhanceLegend(legend) {
+  if (legend.dataset.guideEnhanced === 'true') return;
+  legend.dataset.guideEnhanced = 'true';
+  legend.setAttribute('aria-label', 'How to read the loom');
+  const body = legend.querySelector('.lg-body');
+  if (!body) return;
+  const title = document.createElement('h2');
+  title.className = 'lg-title';
+  title.textContent = 'How to read the loom';
+  body.prepend(title);
+  const lede = body.querySelector('.lg-lede');
+  if (lede) lede.textContent = 'One horizontal thread equals one publication. Left to right is 1880 to 2026.';
+  const rows = body.querySelectorAll('.lg-rows');
+  if (rows[0]) rows[0].textContent = 'Rows are grouped by founding decade. Names appear as you zoom in.';
+  if (rows[1]) rows[1].textContent = 'Drag to move, scroll or pinch to zoom, then select a thread to open the record.';
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'woven-btn lg-cta';
+  button.textContent = 'Start a guided story';
+  button.addEventListener('click', () => toursButton?.click());
+  body.appendChild(button);
+}
+if (stage) {
+  const legendObserver = new MutationObserver(() => handleLoomReady());
+  legendObserver.observe(stage, { childList: true });
+  handleLoomReady();
+}
+fetch('data/publications.json')
+  .then((response) => {
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    return response.json();
+  })
+  .then((data) => {
+    records = Array.isArray(data.publications) ? data.publications : [];
+    recordsReady = true;
+    if ((searchInput?.value || '').trim().length >= 2) renderSearchResults();
+  })
+  .catch(() => {
+    recordsFailed = true;
+    if ((searchInput?.value || '').trim().length >= 2 && searchCount) {
+      searchCount.textContent = 'Search is unavailable. Open the full archive instead.';
+    }
+  });
+function normalize(value) {
+  return (Array.isArray(value) ? value.join(' ') : String(value || '')).toLowerCase();
+}
+function scoreRecord(record, needle) {
+  const name = normalize(record.name);
+  const alternate = normalize(record.alternateName);
+  const city = normalize(record.city);
+  if (name === needle) return 0;
+  if (name.startsWith(needle)) return 1;
+  if (alternate.startsWith(needle)) return 2;
+  if (city.startsWith(needle)) return 3;
+  if (name.includes(needle)) return 4;
+  if (alternate.includes(needle)) return 5;
+  if (city.includes(needle)) return 6;
+  return Infinity;
+}
+function renderSearchResults() {
+  if (!searchInput || !searchResults || !searchCount) return;
+  const needle = searchInput.value.trim().toLowerCase();
+  activeResult = -1;
+  searchInput.removeAttribute('aria-activedescendant');
+  if (needle.length < 2) {
+    matches = [];
+    searchCount.textContent = '';
+    closeSearchResults(false);
+    return;
+  }
+  if (recordsFailed) {
+    closeSearchResults(false);
+    searchCount.textContent = 'Search is unavailable. Open the full archive instead.';
+    return;
+  }
+  if (!recordsReady) {
+    closeSearchResults(false);
+    searchCount.textContent = 'Loading publications…';
+    return;
+  }
+  matches = records
+    .map((record) => ({ record, score: scoreRecord(record, needle) }))
+    .filter((item) => Number.isFinite(item.score))
+    .sort((a, b) => itemOrder(a, b))
+    .map((item) => item.record);
+  searchResults.textContent = '';
+  if (!matches.length) {
+    searchCount.textContent = 'No matching publications.';
+    closeSearchResults(false);
+    return;
+  }
+  const visible = matches.slice(0, 8);
+  visible.forEach((record, index) => searchResults.appendChild(makeResult(record, index)));
+  if (matches.length > visible.length) {
+    const note = document.createElement('p');
+    note.className = 'woven-search-overflow';
+    note.setAttribute('role', 'presentation');
+    note.textContent = `${matches.length - visible.length} more matches. Add another letter to narrow the list.`;
+    searchResults.appendChild(note);
+  }
+  searchCount.textContent = `${matches.length} match${matches.length === 1 ? '' : 'es'}. Choose a result.`;
+  searchResults.hidden = false;
+  searchInput.setAttribute('aria-expanded', 'true');
+}
+function itemOrder(a, b) {
+  return a.score - b.score || String(a.record.name || '').localeCompare(String(b.record.name || ''));
+}
+function makeResult(record, index) {
+  const option = document.createElement('button');
+  option.type = 'button';
+  option.className = 'woven-search-option';
+  option.id = `woven-search-option-${index}`;
+  option.setAttribute('role', 'option');
+  option.setAttribute('aria-selected', 'false');
+  option.dataset.resultIndex = String(index);
+  const name = document.createElement('span');
+  name.className = 'woven-result-name';
+  name.textContent = record.name || 'Untitled publication';
+  const meta = document.createElement('span');
+  meta.className = 'woven-result-meta';
+  meta.textContent = `${record.city || 'city unrecorded'} · ${recordYears(record)}`;
+  option.append(name, meta);
+  return option;
+}
+function recordYears(record) {
+  if (!record.yearFounded) return 'founding year unrecorded';
+  if (record.yearCeased) return `${record.yearFounded}–${record.yearCeased}`;
+  return `${record.yearFounded}–${record.isActive ? 'now' : '?'}`;
+}
+function setActiveResult(index) {
+  const options = Array.from(searchResults?.querySelectorAll('[role="option"]') || []);
+  if (!options.length) return;
+  activeResult = Math.max(0, Math.min(options.length - 1, index));
+  options.forEach((option, i) => option.setAttribute('aria-selected', String(i === activeResult)));
+  const active = options[activeResult];
+  searchInput?.setAttribute('aria-activedescendant', active.id);
+  active.scrollIntoView({ block: 'nearest' });
+}
+function closeSearchResults(clearStatus = false) {
+  if (!searchResults || !searchInput) return;
+  searchResults.hidden = true;
+  searchInput.setAttribute('aria-expanded', 'false');
+  searchInput.removeAttribute('aria-activedescendant');
+  activeResult = -1;
+  if (clearStatus && searchCount) searchCount.textContent = '';
+}
+function chooseResult(record) {
+  if (!record || !searchInput || !searchCount) return;
+  searchInput.value = record.name || '';
+  closeSearchResults(false);
+  searchCount.textContent = `Opening ${record.name}.`;
+  hideCoach(false);
+  openRecordWhenReady(Number(record.id), record.name, 0);
+}
+function openRecordWhenReady(id, name, attempt) {
+  if (window.njbpWoven?.open) {
+    window.njbpWoven.open(id);
+    if (searchCount) searchCount.textContent = `${name} selected.`;
+    return;
+  }
+  if (window.__woven?.app?.select) {
+    window.__woven.app.select(id, {});
+    if (searchCount) searchCount.textContent = `${name} selected.`;
+    return;
+  }
+  if (attempt < 40) {
+    setTimeout(() => openRecordWhenReady(id, name, attempt + 1), 75);
+    return;
+  }
+  location.assign(`${location.pathname}?pub=${encodeURIComponent(id)}`);
+}
+searchInput?.addEventListener('input', (event) => {
+  event.stopImmediatePropagation();
+  renderSearchResults();
+}, true);
+searchInput?.addEventListener('search', (event) => {
+  event.stopImmediatePropagation();
+  renderSearchResults();
+}, true);
+searchInput?.addEventListener('keydown', (event) => {
+  if (event.key === 'ArrowDown' && !searchResults.hidden) {
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    setActiveResult(activeResult + 1);
+  } else if (event.key === 'ArrowUp' && !searchResults.hidden) {
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    setActiveResult(activeResult < 0 ? 0 : activeResult - 1);
+  } else if (event.key === 'Enter' && !searchResults.hidden && matches.length) {
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    chooseResult(matches[activeResult >= 0 ? activeResult : 0]);
+  } else if (event.key === 'Escape' && !searchResults.hidden) {
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    closeSearchResults();
+  }
+}, true);
+searchForm?.addEventListener('submit', (event) => {
+  event.preventDefault();
+  event.stopImmediatePropagation();
+  if (matches.length) chooseResult(matches[activeResult >= 0 ? activeResult : 0]);
+  else renderSearchResults();
+}, true);
+searchResults?.addEventListener('pointerover', (event) => {
+  const option = event.target.closest('[data-result-index]');
+  if (option) setActiveResult(Number(option.dataset.resultIndex));
+});
+searchResults?.addEventListener('click', (event) => {
+  const option = event.target.closest('[data-result-index]');
+  if (option) chooseResult(matches[Number(option.dataset.resultIndex)]);
+});
+document.addEventListener('pointerdown', (event) => {
+  if (searchForm && !searchForm.contains(event.target)) closeSearchResults();
+  if (moreTools?.open && !moreTools.contains(event.target)) moreTools.open = false;
+});
+document.getElementById('btn-reset')?.addEventListener('click', () => {
+  if (searchInput) searchInput.value = '';
+  matches = [];
+  closeSearchResults(true);
+});
+moreTools?.querySelector('.woven-more-panel')?.addEventListener('click', (event) => {
+  if (event.target.closest('button, a')) requestAnimationFrame(() => { moreTools.open = false; });
+});
+moreTools?.addEventListener('keydown', (event) => {
+  if (event.key === 'Escape' && moreTools.open) {
+    event.stopPropagation();
+    moreTools.open = false;
+    moreTools.querySelector('summary')?.focus();
+  }
+});
+let tourWasOpen = false;
+let tourSyncQueued = false;
+function queueTourSync() {
+  if (tourSyncQueued) return;
+  tourSyncQueued = true;
+  requestAnimationFrame(() => {
+    tourSyncQueued = false;
+    syncMobileTour();
+  });
+}
+function syncMobileTour() {
+  if (!tourbar) return;
+  const open = !tourbar.hidden;
+  if (open && !tourWasOpen) document.body.classList.remove('woven-story-expanded');
+  const mobileOpen = open && narrow.matches;
+  document.body.classList.toggle('woven-mobile-tour', mobileOpen);
+  if (!open) document.body.classList.remove('woven-story-expanded');
+  if (mobileOpen) ensureStoryToggle();
+  else tourbar.querySelector('[data-guide-story-toggle]')?.remove();
+  if (open) hideCoach(false);
+  tourWasOpen = open;
+}
+function ensureStoryToggle() {
+  let toggle = tourbar.querySelector('[data-guide-story-toggle]');
+  if (!toggle) {
+    toggle = document.createElement('button');
+    toggle.type = 'button';
+    toggle.className = 'woven-btn';
+    toggle.dataset.guideStoryToggle = '';
+    toggle.setAttribute('aria-controls', 'woven-card');
+    toggle.addEventListener('click', () => {
+      document.body.classList.toggle('woven-story-expanded');
+      updateStoryToggle();
+      window.__woven?.app?.measureChrome?.();
+    });
+    const next = tourbar.querySelector('[data-act="next"], [data-act="end"]');
+    tourbar.insertBefore(toggle, next || tourbar.firstChild);
+  }
+  updateStoryToggle();
+}
+function updateStoryToggle() {
+  const toggle = tourbar?.querySelector('[data-guide-story-toggle]');
+  if (!toggle) return;
+  const expanded = document.body.classList.contains('woven-story-expanded');
+  toggle.textContent = expanded ? 'More loom' : 'Read story';
+  toggle.setAttribute('aria-expanded', String(expanded));
+}
+if (tourbar) {
+  const tourObserver = new MutationObserver(queueTourSync);
+  tourObserver.observe(tourbar, { childList: true, attributes: true, attributeFilter: ['hidden'] });
+  narrow.addEventListener('change', queueTourSync);
+  syncMobileTour();
+}

--- a/docs/woven.html
+++ b/docs/woven.html
@@ -32,9 +32,9 @@
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,300..700&family=Libre+Franklin:wght@400..900&display=swap" rel="stylesheet">
 
     <link rel="stylesheet" href="css/tailwind.css">
-
     <link rel="stylesheet" href="css/styles.css">
     <link rel="stylesheet" href="css/woven.css">
+    <link rel="stylesheet" href="css/woven-guide.css">
 
     <script type="importmap">
     {
@@ -99,56 +99,117 @@
         <section id="woven-intro" class="max-w-[1400px] mx-auto w-full px-4 md:px-8 py-5 md:py-6">
             <div class="intro-grid">
                 <div class="intro-head">
+                    <p class="woven-intro-kicker">An interactive timeline of New Jersey's Black press</p>
                     <h1 class="font-display font-extrabold leading-[1.05] text-linen-50" style="font-size: clamp(1.35rem, 2.9vw, 2.55rem);">A hundred and forty-six years, woven once</h1>
                     <hr class="rail-wood mt-4 max-w-md">
                 </div>
-                <p class="text-base leading-relaxed text-linen-200">Every cross thread here is one publication, starting the year it was founded and ending the year it stopped. The thicker the thread, the more of that paper we have actually found and can show you. The threads that run past the edge of the loom belong to the <span data-count="still">…</span> papers still publishing today. The thin, fraying ones belong to the <span data-count="ghost">…</span> we know only from a line in a librarian's catalog.</p>
+                <div class="woven-intro-copy">
+                    <p class="woven-intro-lede">Each horizontal thread is one publication. Left to right is time. Thread thickness shows how much evidence survives.</p>
+                    <p class="woven-intro-detail"><span data-count="still">…</span> currently publishing titles end in loose strands. <span data-count="ghost">…</span> titles known only from a catalog line appear faint and frayed.</p>
+                    <p class="woven-intro-prompt">Choose a guided story, search for a publication, or explore the whole loom.</p>
+                </div>
             </div>
         </section>
 
         <div id="woven-stage">
+            <p id="woven-canvas-help" class="sr-only">Drag to move across the timeline. Scroll or pinch to zoom. Select a thread to open its publication record. Use the arrow keys to move between publications and events.</p>
             <canvas id="woven-canvas" role="application" tabindex="0"
-                    aria-label="The loom. Every horizontal thread is one New Jersey Black publication, drawn from the year it was founded to the year it stopped. Use the arrow keys to move between publications and decades, or read the same records as a list below."></canvas>
+                    aria-label="Interactive timeline of New Jersey Black publications"
+                    aria-describedby="woven-canvas-help"></canvas>
 
             <div id="woven-chrome">
             <div id="woven-topbar">
-                <div class="bar-scroll">
-                    <button type="button" class="woven-btn" id="btn-help">About this loom</button>
-                    <button type="button" class="woven-btn" id="btn-tours" aria-expanded="false" aria-controls="woven-tourpicker">Guided threads</button>
-                    <button type="button" class="woven-btn" id="btn-ghost">Show what did not survive</button>
-                    <button type="button" class="woven-btn" id="btn-reset">Reset the view</button>
-                    <button type="button" class="woven-btn" id="btn-fullscreen" aria-label="Enter fullscreen" hidden>Fullscreen</button>
-                    <a class="woven-btn" href="#woven-twin">Read the archive as a list</a>
+                <div class="woven-primary-actions" aria-label="Ways to explore the loom">
+                    <button type="button" class="woven-btn woven-primary-btn" id="btn-start">Start here</button>
+                    <button type="button" class="woven-btn woven-primary-btn" id="btn-tours" aria-expanded="false" aria-controls="woven-tourpicker">Guided stories</button>
                 </div>
+
                 <form id="woven-searchform" role="search" autocomplete="off">
-                    <label class="sr-only" for="woven-search">Find a publication</label>
-                    <input id="woven-search" type="search" placeholder="Find a publication" enterkeyhint="go">
-                    <span id="woven-search-count" role="status"></span>
+                    <label class="sr-only" for="woven-search">Search for a publication or city</label>
+                    <div class="woven-search-row">
+                        <input id="woven-search" type="search" placeholder="Search a publication or city" enterkeyhint="search"
+                               role="combobox" aria-autocomplete="list" aria-expanded="false"
+                               aria-controls="woven-search-results">
+                        <button type="submit" class="woven-btn woven-search-submit">Search</button>
+                    </div>
+                    <span id="woven-search-count" role="status" aria-live="polite"></span>
+                    <div id="woven-search-results" role="listbox" aria-label="Publication search results" hidden></div>
                 </form>
+
+                <details id="woven-more-tools">
+                    <summary class="woven-btn">More tools</summary>
+                    <div class="woven-more-panel" aria-label="More loom tools">
+                        <button type="button" class="woven-btn" id="btn-help">How this works</button>
+                        <button type="button" class="woven-btn" id="btn-ghost">What did not survive</button>
+                        <button type="button" class="woven-btn" id="btn-reset">Reset the view</button>
+                        <button type="button" class="woven-btn" id="btn-fullscreen" aria-label="Enter fullscreen" hidden>Fullscreen</button>
+                        <a class="woven-btn" href="#woven-twin">Read as a list</a>
+                    </div>
+                </details>
             </div>
 
             <div id="woven-eranav">
                 <div class="bar-scroll">
-                    <button type="button" class="woven-btn" id="btn-era-prev">Earlier decades</button>
+                    <button type="button" class="woven-btn" id="btn-era-prev" aria-label="Move to earlier founding decades">Previous era</button>
                     <span id="woven-era-now"></span>
-                    <button type="button" class="woven-btn" id="btn-era-next">Later decades</button>
-                    <button type="button" class="woven-btn" id="btn-whole">Show all <span data-count="total">…</span></button>
+                    <button type="button" class="woven-btn" id="btn-era-next" aria-label="Move to later founding decades">Next era</button>
+                    <button type="button" class="woven-btn" id="btn-whole">Whole timeline · <span data-count="total">…</span> titles</button>
                 </div>
-                <span id="woven-eranav-note">You start zoomed out on the whole cloth. Zoom in to read the names.</span>
+                <span id="woven-eranav-note">Names appear when you zoom in. Select a thread to open its record.</span>
             </div>
             </div>
 
             <div id="woven-yearrail" aria-hidden="true"></div>
             <div id="woven-tip" role="presentation" hidden></div>
             <div id="woven-notice" role="status" hidden></div>
-            <div id="woven-empty-hint" role="status" hidden>Nothing here — scroll out or press Reset the view</div>
+            <div id="woven-empty-hint" role="status" hidden>Nothing here — zoom out or reset the view</div>
 
             <div id="woven-overlay" hidden></div>
             <div id="woven-card" hidden></div>
             <div id="woven-ghostnames" hidden></div>
             <div id="woven-ghostcard" hidden></div>
             <div id="woven-help-card" hidden></div>
-            <div id="woven-tourpicker" role="dialog" aria-modal="false" aria-label="Guided threads" hidden></div>
+            <div id="woven-tourpicker" role="dialog" aria-modal="false" aria-label="Guided stories" hidden></div>
+
+            <div id="woven-start-card" role="dialog" aria-modal="false" aria-labelledby="woven-start-title" aria-describedby="woven-start-description" hidden>
+                <div class="woven-guide-inner">
+                    <div class="woven-guide-head">
+                        <div>
+                            <p class="woven-guide-kicker">Start here</p>
+                            <h2 id="woven-start-title">Choose how to explore</h2>
+                        </div>
+                        <button type="button" class="woven-btn" data-guide-close>Close</button>
+                    </div>
+                    <div class="woven-guide-body">
+                        <p id="woven-start-description">The loom holds every publication on one timeline. Pick the route that makes the most sense for what you want to learn.</p>
+                        <div class="woven-start-actions">
+                            <button type="button" class="woven-guide-action" data-guide-action="story">
+                                <span class="woven-guide-action-title">Follow a guided story</span>
+                                <span class="woven-guide-action-copy">Best for a first visit. Move through a short sequence of documented events.</span>
+                            </button>
+                            <button type="button" class="woven-guide-action" data-guide-action="search">
+                                <span class="woven-guide-action-title">Find a publication</span>
+                                <span class="woven-guide-action-copy">Search by title or city, then choose an exact result.</span>
+                            </button>
+                            <button type="button" class="woven-guide-action" data-guide-action="explore">
+                                <span class="woven-guide-action-title">Explore the whole loom</span>
+                                <span class="woven-guide-action-copy">Drag to move, scroll or pinch to zoom, then select a thread.</span>
+                            </button>
+                        </div>
+                        <div class="woven-quick-guide" aria-label="How to explore on your own">
+                            <span><b>1</b> Drag to move</span>
+                            <span><b>2</b> Zoom until names appear</span>
+                            <span><b>3</b> Select a thread for its record</span>
+                        </div>
+                        <p class="woven-guide-list-link">Prefer a conventional index? <a class="link-thread" href="archive.html">Open the full archive</a>.</p>
+                    </div>
+                </div>
+            </div>
+
+            <div id="woven-coach" role="status" hidden>
+                <span><strong>Explore:</strong> drag to move · scroll or pinch to zoom · select a thread</span>
+                <button type="button" aria-label="Hide exploration instructions">Got it</button>
+            </div>
 
             <aside id="woven-panel" role="dialog" aria-modal="false" aria-labelledby="woven-panel-title" hidden></aside>
 
@@ -186,6 +247,7 @@
         </footer>
     </main>
 
+    <script type="module" src="js/woven/guide.js"></script>
     <script type="module" src="js/woven/main.js"></script>
     <script>
         (function () {


### PR DESCRIPTION
## What changed

- Rewrote the introduction so the timeline, publication threads, evidence thickness, loose ends, and faint catalog-only records are understandable before interaction.
- Added a first-session **Start here** chooser with three clear routes: follow a guided story, find a publication, or explore the whole loom.
- Replaced search-driven camera movement while typing with an explicit, keyboard-accessible result list. The loom moves only after the reader chooses a publication.
- Promoted the core tasks and moved explanation, missing-material mode, reset, fullscreen, and the list view under **More tools**.
- Renamed and clarified the era controls, canvas instructions, legend, and guided-story picker.
- Added a dismissible in-canvas interaction hint that disappears once the reader starts using the loom.
- On small screens, guided stories now start with a compact summary so the loom remains visible. Readers can switch between **Read story** and **More loom** at any stop. This addresses #58.
- Kept direct publication/story links, the accessible list twin, and the existing Three.js rendering and evidence logic intact.

## Why

The existing first screen exposed too many equally weighted controls and expected readers to understand the loom metaphor before they could act. Search also moved the camera while a reader was still typing, which made the interface feel unstable. This pass makes the first decision explicit, reveals advanced tools only when requested, and ensures each interaction has a predictable result.

## Validation

- `python data/test_woven_usability.py`
- `node --check docs/js/woven/guide.js`
- Headless Chromium flow at 1440×900: first-run chooser, keyboard search, explicit selection, More tools, and reset
- Headless Chromium flow at 375×812: first-run route and mobile Read story / More loom toggle
- Remote branch blobs verified byte-for-byte against the locally tested files
- Branch comparison: 4 commits ahead of `master`, 0 behind

## Scope and risk

This is an additive interface layer. It does not change the publication data, story data, shaders, geometry, camera controls, selection logic, or evidence rendering. No new Tailwind utility classes were introduced, so the compiled Tailwind stylesheet does not need to be rebuilt.

## Review focus

1. Can a first-time visitor explain what the loom represents within a few seconds?
2. Can that visitor start a story, find a publication, or explore without guessing?
3. Does selecting a search result feel more stable than moving the camera on every keystroke?
4. At 375×812, is there a meaningful band of loom visible beside the story summary?