### PR TITLE
Refresh repository guides for the current archive

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,40 @@
+name: Site problem
+description: Report a broken page, interaction, or accessibility problem.
+title: "Bug: "
+labels:
+  - bug
+body:
+  - type: input
+    id: page
+    attributes:
+      label: Page URL
+      description: Paste the exact archive URL where the problem occurs.
+      placeholder: https://centercoopmedia.github.io/njblackpress/
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What happened?
+      description: Describe the result you saw and the result you expected.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: List the shortest steps that show the problem.
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Browser and device
+      placeholder: Firefox 142 on Windows 11
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add screenshots, screen-reader details, or other useful context.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: View the live archive
+    url: https://centercoopmedia.github.io/njblackpress/
+    about: Check the published archive before you report a problem.

--- a/.github/ISSUE_TEMPLATE/data_correction.yml
+++ b/.github/ISSUE_TEMPLATE/data_correction.yml
@@ -1,0 +1,49 @@
+name: Data correction
+description: Propose a sourced correction or addition to a publication record.
+title: "Data: "
+labels:
+  - data
+body:
+  - type: input
+    id: publication
+    attributes:
+      label: Publication
+      description: Give the publication name and archive record URL when available.
+    validations:
+      required: true
+  - type: input
+    id: field
+    attributes:
+      label: Field
+      description: Name the field that needs a correction or addition.
+      placeholder: Founding year
+    validations:
+      required: true
+  - type: textarea
+    id: correction
+    attributes:
+      label: Proposed correction
+      description: State the current value and the proposed value.
+    validations:
+      required: true
+  - type: textarea
+    id: sources
+    attributes:
+      label: Sources
+      description: Add reliable links or full citations that support the correction.
+    validations:
+      required: true
+  - type: textarea
+    id: rights
+    attributes:
+      label: Rights and access notes
+      description: Explain any reuse, access, credit, or copyright limits on supporting files.
+    validations:
+      required: true
+  - type: checkboxes
+    id: copyright
+    attributes:
+      label: File sharing
+      options:
+        - label: I have not uploaded copyrighted newspaper pages without permission.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,34 @@
+## Summary
+
+[Describe the result in one or two sentences.]
+
+## Why
+
+[Explain the reader, researcher, or maintenance need.]
+
+## Change type
+
+- [ ] Data correction or research update
+- [ ] Interface or accessibility change
+- [ ] Data pipeline or generator change
+- [ ] Documentation or maintenance
+
+## Source and rights
+
+[List sources and evidence rights. Write `Not applicable` when no data or evidence changes.]
+
+## Validation
+
+- [ ] Ran the focused data or interface checks
+- [ ] Rebuilt Tailwind when class names changed
+- [ ] Regenerated affected browser data or wiki files
+- [ ] Checked visible changes in a browser
+- [ ] Added screenshots, or this change has no visible effect
+
+## Deployment notes
+
+[List live-site checks or follow-up. Write `None` when no follow-up is needed.]
+
+## Reviewer notes
+
+[List decisions, risks, or areas that need close review.]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,8 +61,13 @@ large research files are ignored by Git and are not present in a normal clone.
 
 - Read `data/DATA_DICTIONARY.md` before changing a data contract.
 - Keep pipeline data and browser data copies equal.
+- Treat `data/publications.json` as the current publication record.
+- Do not run `data/convert_csv.py` for a routine correction.
+- Copy and compare featured data after you change its source file.
 - Do not hand-edit publication evidence arrays.
 - Do not publish evidence without a permitted rights status.
+- Rebuild the clipping index after a rights change.
+- Remove an old public evidence image after its rights status is downgraded.
 - Preserve publication IDs and verify all cross-file references.
 - Regenerate the map and both wikis after applicable publication changes.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,84 @@
+# Repository guidelines
+
+`CLAUDE.md` is the authoritative project brief. Keep this file aligned with it
+when project behavior changes.
+
+## Project context
+
+This repository contains the NJ Black Press Archive static site and its data
+pipeline. GitHub Pages serves `docs/` from `master`.
+
+The project has no backend, database server, authentication, or write API.
+
+## Important paths
+
+- `docs/`: Published site and browser data.
+- `docs/js/woven/`: Woven ES modules.
+- `data/`: Pipeline data, research inputs, builders, and checks.
+- `data/research/source-catalog.json`: Evidence provenance.
+- `data/research/rights/rights-manifest.json`: Evidence rights decisions.
+- `scripts/`: Public and portable wiki generators.
+- `okf/`: Generated portable wiki.
+- `src/input.css`: Tailwind source.
+
+## Generated files
+
+Do not hand-edit these outputs:
+
+- `docs/css/tailwind.css`
+- Browser data under `docs/data/`
+- `data/map-publications.json`
+- `docs/wiki/`
+- `okf/`
+
+Update the source and run its builder. Review generated diffs before commit.
+
+## Common commands
+
+```bash
+npm ci
+npm run build:css
+cd docs && python3 -m http.server 8000
+```
+
+Common focused checks:
+
+```bash
+python3 data/test_site_data.py
+python3 data/test_source_catalog.py
+python3 data/test_map.py
+python3 data/test_navigation.py
+python3 data/test_wiki_publications.py
+python3 data/test_woven_layout.py
+python3 data/test_woven_usability.py
+python3 scripts/generate_okf_wiki.py --check
+```
+
+The evidence and source-catalog checks require the local evidence corpus. Most
+large research files are ignored by Git and are not present in a normal clone.
+
+## Data and evidence rules
+
+- Read `data/DATA_DICTIONARY.md` before changing a data contract.
+- Keep pipeline data and browser data copies equal.
+- Do not hand-edit publication evidence arrays.
+- Do not publish evidence without a permitted rights status.
+- Preserve publication IDs and verify all cross-file references.
+- Regenerate the map and both wikis after applicable publication changes.
+
+## Interface rules
+
+- Use sentence case for headings and interface text.
+- Preserve keyboard access, focus behavior, reduced motion, and semantic HTML.
+- Use complete Tailwind class strings in JavaScript.
+- Rebuild Tailwind after a class change.
+- Check visible changes at desktop and mobile sizes.
+
+## Pull requests
+
+Keep each pull request focused. Explain the source and rights basis for data or
+evidence changes. Include screenshots for visible changes and name every check
+you ran.
+
+Do not merge without Joe's approval. After a merged achievement, add the
+required plain-language update to the Road to launch discussion.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,116 +1,159 @@
-# CLAUDE.md
-
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+# NJ Black Press Archive: Repository instructions
 
 ## Project overview
 
-NJ Black Press Database — a static site documenting ~140 Black-owned and Black-focused publications in New Jersey from 1880 to present. Built for the Center for Cooperative Media at Montclair State University. Hosted on GitHub Pages from the `docs/` folder.
+This repository contains a static historical archive of Black-owned and
+Black-focused publications in New Jersey from 1880 to the present. The Center
+for Cooperative Media at Montclair State University maintains it.
+
+GitHub Pages publishes the `docs/` directory from `master`. The live site is
+`https://centercoopmedia.github.io/njblackpress/`.
+
+The project has no backend, database server, or JavaScript framework.
 
 ## Development
 
-The site is vanilla HTML/JS/CSS, no framework and no bundler. To develop locally, serve the `docs/` folder with any static server:
+The site uses static HTML, CSS, and JavaScript. Tailwind CSS is compiled, not
+loaded from a CDN.
 
 ```bash
-cd docs && python -m http.server 8000
-```
-
-**Tailwind is compiled, not CDN.** Every page loads `docs/css/tailwind.css`. That file is generated — never hand-edit it. Rebuild it after you add or change any Tailwind class in HTML or JS:
-
-```bash
-npm install      # first time only
+npm ci
 npm run build:css
+cd docs
+python3 -m http.server 8000
 ```
 
-The build reads `tailwind.config.js` (palettes, fonts, `bg-noise`) and `src/input.css`, and scans `./docs/**/*.html` plus `./docs/js/**/*.js`. Classes built in JS must appear as complete literal strings, or Tailwind will not emit them; if you must concatenate a class name, add it to `safelist` in `tailwind.config.js`. `scripts/generate_html_wiki.py` runs the build for you at the end (pass `--skip-css` to opt out).
+`docs/css/tailwind.css` is generated. Never edit it by hand. Rebuild it after
+you add or change a Tailwind class in HTML or JavaScript.
 
-**Data pipeline:** Notion → CSV export → Python conversion → JSON
+Tailwind scans `docs/**/*.html` and `docs/js/**/*.js`. JavaScript class names
+must use complete literal strings. Add a dynamic class to the safelist in
+`tailwind.config.js` when a literal is not possible.
+
+## Site architecture
+
+Main pages:
+
+- `docs/index.html`: Home, featured records, timeline, and search.
+- `docs/archive.html`: Filterable publication directory.
+- `docs/publication.html`: Publication detail selected with `?id=`.
+- `docs/story.html`: Sourced narrative selected with `?id=`.
+- `docs/era.html`: Historical era selected with `?id=`.
+- `docs/map.html`: Publication map and decade filter.
+- `docs/woven.html`: Interactive timeline loom.
+- `docs/wiki/`: Generated public HTML wiki.
+
+The scripts in `docs/js/` support the main site. Most older scripts use the
+IIFE pattern. Woven uses ES modules under `docs/js/woven/` and vendored Three.js
+files under `docs/vendor/`.
+
+`docs/js/site-nav.js` defines the shared site navigation. Update its regression
+check when you change the global navigation.
+
+## Data sources
+
+- `data/publications.csv`: Notion export for base publication fields.
+- `data/publications.json`: Pipeline publication data.
+- `data/research/source-catalog.json`: Source searches and retained evidence.
+- `data/research/rights/rights-manifest.json`: Rights decisions for evidence.
+- `data/research/editorial/events.json`: Editorial event source.
+- `data/research/editorial/stories.json`: Editorial story source.
+- `data/municipality-centers.json`: Map grouping and coordinate rules.
+- `data/featured-publications.json`: Hand-curated featured records.
+
+Read `data/DATA_DICTIONARY.md` before you change a data contract.
+
+## Generated files
+
+Do not hand-edit these outputs:
+
+- `docs/css/tailwind.css`
+- `docs/data/publications.json`
+- `docs/data/events.json`
+- `docs/data/stories.json`
+- `data/map-publications.json`
+- `docs/data/map-publications.json`
+- `docs/wiki/`
+- `okf/`
+
+Run the smallest builder that covers the source change:
 
 ```bash
-cd data && python convert_csv.py
+cd data
+python3 convert_csv.py
+python3 merge_research.py
+python3 add_evidence.py
+cd ..
+python3 data/build_site_events_stories.py
+python3 data/build_map_data.py
+python3 scripts/generate_html_wiki.py --base-url https://centercoopmedia.github.io/njblackpress/
+python3 scripts/generate_okf_wiki.py
+python3 scripts/generate_okf_wiki.py --check
 ```
 
-This reads `data/publications.csv` and outputs `data/publications.json`. The generated JSON must then be copied to `docs/data/publications.json` for the frontend. `docs/data/featured-publications.json` is hand-curated and edited directly.
+`convert_csv.py` rebuilds publication data from the CSV and reattaches evidence.
+Run `merge_research.py` and `add_evidence.py` after it when research enrichment
+must also be applied and copied to the browser data.
 
-## Architecture
+The HTML wiki generator also rebuilds Tailwind unless `--skip-css` is present.
+Always pass the live Pages URL through `--base-url`.
 
-Static site with three HTML pages, no framework, no bundler:
+## Evidence and rights
 
-- **`docs/index.html`** — Landing page (hero, featured sections, timeline, searchable database, about)
-- **`docs/archive.html`** — Full archive with list/grid toggle, filters, sorting, pagination
-- **`docs/publication.html`** — Individual publication detail (loaded via `?id=X` query param)
-- **`docs/wiki/`** — Pre-rendered public wiki (one HTML page per publication/city/decade/format/medium, plus statistics and featured pages). Generated by `scripts/generate_html_wiki.py`; do NOT hand-edit. Served at `/njblackpress/wiki/` and linked from the main nav.
+Evidence is traceable by publication ID through the source catalog. The rights
+manifest controls whether each evidence file can be published.
 
-### JavaScript modules (IIFE pattern, no imports)
+Do not hand-edit a publication's `evidence` array. Update the source catalog or
+rights manifest, then run `data/add_evidence.py`.
 
-- **`docs/js/app.js`** — Core state management, filtering, search, pagination, card rendering. Exposes `window.njbp` for cross-module communication (`removeFilter`, `resetFilters`, `getState`, `filterByDecade`).
-- **`docs/js/timeline.js`** — Interactive decade timeline with bar chart visualization. Calls `window.njbp.filterByDecade()`.
-- **`docs/js/featured.js`** — Loads and merges `featured-publications.json` with main data for rich featured sections.
-- **`docs/js/archive.js`** — Archive page filtering and display logic.
-- **`docs/js/publication.js`** — Detail page rendering from query param ID.
+Do not publish a file marked `metadata_only` or `unlisted`. Follow the citation
+and crop requirements for `publishable_with_credit` and `crop_first` files.
 
-### State management
+## Validation
 
-`app.js` uses a single `state` object with `publications`, `filteredPublications`, `filters` (search, city, decade, status, format), `sortBy`, `currentPage`, and `perPage` (24). Filters are applied sequentially; search is debounced at 300ms.
+Run the focused checks for the changed area. Useful checks include:
 
-## Data model
+```bash
+npm run build:css
+python3 data/test_site_data.py
+python3 data/test_source_catalog.py
+python3 data/test_map.py
+python3 data/test_navigation.py
+python3 data/test_wiki_publications.py
+python3 data/test_woven_layout.py
+python3 data/test_woven_usability.py
+python3 scripts/generate_okf_wiki.py --check
+```
 
-**`publications.json`** contains an array of publication objects and a `metadata` block (totalCount, cities, decades, formats, activeCount, ceasedCount). Each publication has: `id`, `name`, `alternateName`, `city`, `publishers`, `yearFounded`, `yearCeased`, `frequency`, `format`, `medium` (computed: Print/Digital/Print+Digital), `languages`, `primaryFocus`, `missionStatement`, `historicalNotes`, `archiveUrl`, `websiteUrl`, `targetAudience`, `keyStaff`, `isActive` (computed: true if yearCeased is null), `decade` (computed from yearFounded).
+`test_evidence.py` and `test_source_catalog.py` require the local evidence
+corpus. Git ignores most large research files, so those checks fail in a normal
+clone without the corpus.
 
-**`featured-publications.json`** has `featuredHistoric` (11 entries) and `featuredContemporary` (5 entries) with expanded fields: `founders`, `keyStaff` as objects (`{name, role}`), `tags`, `physicalArchive`.
-
-## Styling
-
-Tailwind CSS via CDN with inline config extending colors and fonts:
-
-- **Colors:** ink-950 through ink-700 (dark backgrounds), paper-50 through paper-300 (light text), accent #ff4d00 (orange)
-- **Fonts:** Fraunces (serif headings), DM Sans (body), system monospace (labels/filters)
-- **Custom CSS** in `docs/css/styles.css`: scrollbar styling, noise grain overlay, timeline bars
+Data changes must keep source and browser copies equal. Generated wiki changes
+must include their generated outputs. Visible changes need desktop and mobile
+browser checks.
 
 ## Deployment
 
-**GitHub Pages is the live site (as of 2026-08-19).** Pages serves the latest push from the `docs/` folder, so **push = deploy**. Live URL: `https://centercoopmedia.github.io/njblackpress/`.
+GitHub Pages uses the `master` branch and the `docs/` directory. A merge that
+changes `docs/` publishes those changes. Verify the Pages build and the live
+route after merge.
 
-The former production host at `centerforcooperativemedia.org/njblackpress/` is dead — the CCM WordPress server migrated off 37.27.121.163 and the SFTP endpoint no longer exists. Joe confirmed the GitHub Pages URL is the home for now. The SFTP instructions below are retained only for the day CCM hosting returns; do NOT attempt them without a new endpoint from the Nestify dashboard.
+Do not use the retired SFTP deployment instructions or the former WordPress
+host without a new, verified deployment decision.
 
-**SFTP deploy (from officejawn or houseofjawn):**
-```bash
-# Credentials in pass store
-HOST=37.27.121.163
-PORT=4377
-USER=$(~/.claude/pass-get claude/services/ccm-ftp-user)
-PASS=$(~/.claude/pass-get claude/services/ccm-ftp-pass)
+## Project updates
 
-# Upload all static files
-sshpass -p "$PASS" scp -P $PORT -o StrictHostKeyChecking=no docs/*.html docs/*.xml docs/*.txt docs/*.png docs/*.svg $USER@$HOST:public_html/njblackpress/
-sshpass -p "$PASS" scp -P $PORT -o StrictHostKeyChecking=no docs/css/* $USER@$HOST:public_html/njblackpress/css/
-sshpass -p "$PASS" scp -P $PORT -o StrictHostKeyChecking=no docs/js/* $USER@$HOST:public_html/njblackpress/js/
-sshpass -p "$PASS" scp -P $PORT -o StrictHostKeyChecking=no docs/data/* $USER@$HOST:public_html/njblackpress/data/
-
-# Upload the pre-rendered wiki (recursive — it has cities/, decades/, formats/, mediums/, publications/ subdirs)
-sshpass -p "$PASS" scp -rP $PORT -o StrictHostKeyChecking=no docs/wiki $USER@$HOST:public_html/njblackpress/
-```
-
-**Live URLs:**
-- Production (live): `https://centercoopmedia.github.io/njblackpress/` (GitHub Pages, serves the latest push)
-- Former production (dead): `https://centerforcooperativemedia.org/njblackpress/` (CCM server migrated; may return later)
-
-**Data pipeline caveat:** The JSON has been enriched with fields (`historicalNotes`, `missionStatement`, etc.) that don't exist in the CSV. Do NOT re-run `convert_csv.py` to regenerate the JSON — it will wipe those fields. Edit the JSON directly for metadata changes.
-
-**Regenerate the wikis after any data change** so they stay in sync with `data/publications.json`:
-```bash
-python3 scripts/generate_html_wiki.py            # public HTML wiki under docs/wiki/
-python3 scripts/generate_okf_wiki.py             # portable markdown bundle under okf/
-python3 scripts/generate_okf_wiki.py --check     # validate the markdown bundle
-```
-Both accept `--generated-at YYYY-MM-DD` for reproducible timestamps. The HTML generator reuses helpers from the OKF generator, so keep them together.
-
-## Project updates (mandatory)
-
-After every achievement or merged PR, post a plain-English update as a comment on the "Road to launch" GitHub discussion (https://github.com/CenterCoopMedia/njblackpress/discussions/47) so nontechnical colleagues (Cassandra Etienne) can follow along. No jargon, no file paths, 3–6 sentences: what happened, why it matters for the archive, what comes next. An achievement is not done until its update is posted.
+After a merged achievement, post a plain-language update to the
+[Road to launch discussion](https://github.com/CenterCoopMedia/njblackpress/discussions/47).
+Use three to six sentences. Explain what changed, why it matters, and what
+comes next. Do not include file paths or engineering jargon.
 
 ## Conventions
 
-- Sentence case for all headings and UI text (never Title Case)
-- CCM brand colors: #000000 (black) and #CA3553 (red) for organizational branding; site uses its own palette (ink/paper/accent)
-- External links open in new tabs with `target="_blank" rel="noopener noreferrer"`
-- Publication detail pages use client-side routing via query params, not separate HTML files per publication
+- Use sentence case for headings and interface text.
+- Open external links in a new tab with `target="_blank"` and
+  `rel="noopener noreferrer"`.
+- Use query parameters for publication, story, and era detail routes.
+- Keep changes focused. Do not edit generated files without their source.
+- Preserve unrelated worktree changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ Main pages:
 - `docs/archive.html`: Filterable publication directory.
 - `docs/publication.html`: Publication detail selected with `?id=`.
 - `docs/story.html`: Sourced narrative selected with `?id=`.
-- `docs/era.html`: Historical era selected with `?id=`.
+- `docs/era.html`: Historical era selected with `?decade=`.
 - `docs/map.html`: Publication map and decade filter.
 - `docs/woven.html`: Interactive timeline loom.
 - `docs/wiki/`: Generated public HTML wiki.
@@ -52,8 +52,8 @@ check when you change the global navigation.
 
 ## Data sources
 
-- `data/publications.csv`: Notion export for base publication fields.
-- `data/publications.json`: Pipeline publication data.
+- `data/publications.json`: Current publication record.
+- `data/publications.csv`: Notion export for a controlled full refresh only.
 - `data/research/source-catalog.json`: Source searches and retained evidence.
 - `data/research/rights/rights-manifest.json`: Rights decisions for evidence.
 - `data/research/editorial/events.json`: Editorial event source.
@@ -69,8 +69,11 @@ Do not hand-edit these outputs:
 
 - `docs/css/tailwind.css`
 - `docs/data/publications.json`
+- `docs/data/featured-publications.json`
 - `docs/data/events.json`
 - `docs/data/stories.json`
+- `docs/data/clippings.json`
+- `docs/images/evidence/`
 - `data/map-publications.json`
 - `docs/data/map-publications.json`
 - `docs/wiki/`
@@ -79,11 +82,9 @@ Do not hand-edit these outputs:
 Run the smallest builder that covers the source change:
 
 ```bash
-cd data
-python3 convert_csv.py
-python3 merge_research.py
-python3 add_evidence.py
-cd ..
+python3 data/add_evidence.py
+cp data/featured-publications.json docs/data/featured-publications.json
+cmp data/featured-publications.json docs/data/featured-publications.json
 python3 data/build_site_events_stories.py
 python3 data/build_map_data.py
 python3 scripts/generate_html_wiki.py --base-url https://centercoopmedia.github.io/njblackpress/
@@ -91,9 +92,15 @@ python3 scripts/generate_okf_wiki.py
 python3 scripts/generate_okf_wiki.py --check
 ```
 
-`convert_csv.py` rebuilds publication data from the CSV and reattaches evidence.
-Run `merge_research.py` and `add_evidence.py` after it when research enrichment
-must also be applied and copied to the browser data.
+The checked-in CSV is stale relative to the current publication record. Do not
+run `data/convert_csv.py` for a routine correction. Use it only for a controlled
+full refresh after you replace the CSV with a fresh Notion export. Review the
+full diff and prove that the refresh preserves curated fields, record count,
+publication IDs, cessation years, and active status.
+
+For a routine publication correction, update `data/publications.json`, run
+`data/add_evidence.py`, and review both publication JSON files. Use
+`data/merge_research.py` only for a reviewed research-enrichment batch.
 
 The HTML wiki generator also rebuilds Tailwind unless `--skip-css` is present.
 Always pass the live Pages URL through `--base-url`.
@@ -108,6 +115,13 @@ rights manifest, then run `data/add_evidence.py`.
 
 Do not publish a file marked `metadata_only` or `unlisted`. Follow the citation
 and crop requirements for `publishable_with_credit` and `crop_first` files.
+
+A rights change also affects the public clipping index and its image files. In
+a checkout with the full evidence corpus, record the affected clipping output,
+then run `python3 data/make_clippings.py`. Remove each old file under
+`docs/images/evidence/` that the new `docs/data/clippings.json` no longer lists.
+Confirm that a downgraded source path is absent from the clipping index and its
+old public image no longer exists. Review both paths before commit.
 
 ## Validation
 
@@ -154,6 +168,6 @@ comes next. Do not include file paths or engineering jargon.
 - Use sentence case for headings and interface text.
 - Open external links in a new tab with `target="_blank"` and
   `rel="noopener noreferrer"`.
-- Use query parameters for publication, story, and era detail routes.
+- Use `?id=` for publication and story details. Use `?decade=` for era details.
 - Keep changes focused. Do not edit generated files without their source.
 - Preserve unrelated worktree changes.

--- a/CODEBASE_OVERVIEW.md
+++ b/CODEBASE_OVERVIEW.md
@@ -1,131 +1,114 @@
-# NJ Black Press Database — Codebase Overview
+# NJ Black Press Archive: Codebase overview
 
-## What It Does
+## System boundary
 
-A static website cataloging **138+ Black publications in New Jersey from 1880 to present**. It provides a searchable/filterable archive, featured publication showcases, an interactive decade-by-decade timeline, and individual publication detail pages. Built for the **Center for Cooperative Media** at Montclair State University.
+The project is a static site. Browsers load HTML, CSS, JavaScript, and JSON from
+GitHub Pages. There is no application server, database server, authentication,
+or write API.
 
-## Tech Stack
+Python scripts build data and pre-rendered pages before publication. GitHub
+Pages serves the committed results from `docs/`.
 
-| Layer | Technology |
-|---|---|
-| Markup | Static HTML5 (3 pages) |
-| Styling | Tailwind CSS 3 (CDN) + custom CSS |
-| JavaScript | Vanilla ES6+ (~2,000 LOC across 5 IIFE modules, no framework) |
-| Data | Static JSON files (no database, no backend server) |
-| Data pipeline | Python 3 scripts (CSV → JSON conversion) |
-| Hosting | GitHub Pages (served from `docs/` folder) |
-| Fonts | Google Fonts (Fraunces serif, DM Sans sans-serif) |
+## Public surfaces
 
-## Main Entry Points
+| Surface | Entry point | Main data |
+|---|---|---|
+| Home and timeline | `docs/index.html` | Publications and featured records |
+| Archive | `docs/archive.html` | Publications |
+| Publication detail | `docs/publication.html?id=` | Publications, evidence, and recent stories |
+| Stories | `docs/story.html?id=` | Stories, events, and publications |
+| Eras | `docs/era.html?id=` | Events, stories, and publications |
+| Map | `docs/map.html` | Generated map publication data |
+| Woven | `docs/woven.html` | Publications, stories, events, and evidence |
+| Public wiki | `docs/wiki/` | Pre-rendered publication and browse pages |
+| Portable wiki | `okf/` | Markdown pages with YAML frontmatter |
 
-### Pages
+## Frontend organization
 
-- **`docs/index.html`** — Homepage with hero stats, hardcoded featured publications, interactive timeline, and database search section
-- **`docs/archive.html`** — Full searchable/filterable directory with grid and list views, URL state persistence
-- **`docs/publication.html`** — Individual publication detail page (loaded via `?id=` query parameter)
+The main site scripts live in `docs/js/`:
 
-### JavaScript Modules
+- `app.js`: Home data loading, filters, cards, and counters.
+- `archive.js`: Archive filters, sorting, URL state, and pagination.
+- `publication.js`: Publication details, evidence, and related records.
+- `featured.js`: Featured record sections.
+- `timeline.js`: Decade timeline.
+- `story.js`: Story detail rendering.
+- `era.js`: Era detail rendering.
+- `map.js`: Map rendering and decade filtering.
+- `site-nav.js`: Shared navigation.
 
-All modules use the IIFE pattern and are loaded per-page:
+Woven uses ES modules under `docs/js/woven/`. Its modules separate data,
+layout, rendering, labels, selection, story tours, evidence panels, fallback
+behavior, and first-visit guidance. Three.js is vendored under `docs/vendor/`.
 
-- **`docs/js/app.js`** (~490 lines) — Homepage: data loading, filtering, search, card rendering, counter animation
-- **`docs/js/archive.js`** (~607 lines) — Archive page: advanced filters, URL state sync, grid/list views, pagination
-- **`docs/js/publication.js`** (~440 lines) — Detail page: multi-source data loading, rich content rendering, related publications
-- **`docs/js/featured.js`** (~299 lines) — Featured publications rendering with expand/collapse
-- **`docs/js/timeline.js`** (~231 lines) — Interactive bar chart timeline with decade navigation
+## Styling
 
-### Data Pipeline
+`src/input.css` is the Tailwind input. `tailwind.config.js` defines scan paths,
+fonts, colors, and the noise texture. `npm run build:css` writes the minified
+stylesheet to `docs/css/tailwind.css`.
 
-- **`data/publications.csv`** — Master source data (exported from Notion)
-- **`data/convert_csv.py`** — Converts CSV → `publications.json` with derived fields (decade, isActive, medium)
-- **`data/merge_research.py`** — Merges enriched research data into publication records
-- **`data/publications.json`** — Runtime data file (138 publications with full metadata)
-- **`data/featured-publications.json`** — Enriched data for highlighted publications
-- **`data/research/`** — 6 batch JSON files of historical research findings
-- **`data/publications/`** — 130+ individual Markdown files per publication
+Custom styles live in:
 
-## Project Structure
+- `docs/css/styles.css`: Shared site styles.
+- `docs/css/woven.css`: Woven layout and rendering interface.
+- `docs/css/woven-guide.css`: Woven guidance and progressive controls.
 
+## Data flow
+
+```text
+Notion CSV
+  -> data/convert_csv.py
+  -> data/publications.json
+
+Research batches
+  -> data/merge_research.py
+  -> data/publications.json
+
+Source catalog + rights manifest
+  -> data/add_evidence.py
+  -> data/publications.json
+  -> docs/data/publications.json
+
+Editorial events and stories
+  -> data/build_site_events_stories.py
+  -> data/events.json and data/stories.json
+  -> docs/data/events.json and docs/data/stories.json
+
+Publications + municipality rules
+  -> data/build_map_data.py
+  -> data/map-publications.json
+  -> docs/data/map-publications.json
+
+Publication data
+  -> scripts/generate_html_wiki.py
+  -> docs/wiki/
+  -> scripts/generate_okf_wiki.py
+  -> okf/
 ```
-njblackpress/
-├── docs/                          # Static website (GitHub Pages root)
-│   ├── index.html                 # Homepage
-│   ├── archive.html               # Full archive directory
-│   ├── publication.html           # Publication detail template
-│   ├── css/styles.css             # Custom CSS (scrollbars, animations, responsive)
-│   ├── js/                        # JavaScript modules
-│   │   ├── app.js
-│   │   ├── archive.js
-│   │   ├── featured.js
-│   │   ├── timeline.js
-│   │   └── publication.js
-│   ├── data/                      # Runtime data files
-│   │   ├── publications.json
-│   │   └── featured-publications.json
-│   └── images/
-├── data/                          # Data layer (source of truth)
-│   ├── publications.csv           # Master CSV from Notion
-│   ├── publications.json          # Generated JSON
-│   ├── featured-publications.json
-│   ├── convert_csv.py             # CSV → JSON converter
-│   ├── merge_research.py          # Research data merger
-│   ├── publications/              # Individual markdown records (130+)
-│   └── research/                  # Batch research JSON files
-└── README.md
-```
 
-## Security Vulnerabilities
+The `data/` copies are pipeline data. The `docs/data/` copies are browser data.
+Builders keep the paired files equal.
 
-### 1. XSS via unescaped URLs in `href` attributes (Medium)
+## Generated boundaries
 
-Multiple files interpolate `pub.websiteUrl` and `pub.archiveUrl` directly into HTML `href` attributes without escaping. While text content is properly escaped via `escapeHtml()`, URLs are not. A value like `javascript:alert(1)` in the JSON data would execute.
+Do not hand-edit compiled CSS, browser data copies, or generated wiki files.
+Change the source and run its builder.
 
-**Affected locations:**
-- `app.js:276-279` — `websiteLink` and `archiveLink`
-- `archive.js:373-376` — `pub.websiteUrl` in grid cards
-- `publication.js:324,335` — `pub.websiteUrl` and `pub.archiveUrl`
-- `featured.js:104,207` — `pub.archiveUrl` and `websiteUrl`
+The public HTML wiki generator removes and rebuilds `docs/wiki/`. The open
+knowledge format generator removes and rebuilds `okf/`. Review the full
+generated diff before commit.
 
-The `archiveUrl.startsWith('http')` check in some places partially mitigates this, but `websiteUrl` has no such guard.
+## Validation model
 
-### 2. Inline `onclick` handlers with string interpolation (Low)
+The repository uses small Python checks in `data/test_*.py`. Each check covers
+a stable data, navigation, map, wiki, or Woven contract. Run the checks that
+match the changed surface.
 
-- `app.js:365` — `onclick="window.njbp.removeFilter('${f.type}')"`
-- `archive.js:437-443` — Same pattern with `chip.type`
-- `timeline.js:209` — `onclick="window.njbp.filterByDecade('${decade.label}')"`
+Browser checks remain necessary for layout, keyboard interaction, focus,
+responsive behavior, WebGL, and reduced motion.
 
-Values currently come from hardcoded sources so this is safe in practice, but the pattern is fragile and invites injection if data sources change.
+## Publication
 
-### 3. URL parameters used without validation (Low)
-
-`archive.js:63-71` reads `sort` and `view` from URL params and sets them directly into state without validating against allowed values. This doesn't lead to XSS but crafted URLs could produce unexpected UI behavior.
-
-### 4. Tailwind CSS CDN loaded without Subresource Integrity (Low)
-
-**Resolved 2026-08-19:** the site now ships a compiled `docs/css/tailwind.css`; no page loads the Tailwind CDN.
-
-## Inefficiencies
-
-### 1. Triple-loading `publications.json` on the homepage
-
-The homepage loads `app.js`, `timeline.js`, and (if included) `featured.js`, each of which independently `fetch('data/publications.json')`. That's up to 3 identical HTTP requests on every homepage load. Browser caching helps on repeat visits but the first load is wasteful. A shared data loader would fix this.
-
-### 2. Full DOM re-render on every filter/sort change
-
-`app.js:260` and `archive.js:335` reconstruct the entire results grid via `innerHTML = ...map(...).join('')` on every interaction. For 138 records this is fast enough, but it discards and recreates all DOM nodes unnecessarily.
-
-### 3. Duplicated utility functions across all 5 JS files
-
-`escapeHtml()`, `truncate()`, `debounce()`, `animateCounter()`, `getOneLiner()`, and `hideLoadingOverlay()` are copy-pasted across multiple files. Bug fixes must be applied in 3-5 places.
-
-### 4. Tailwind CSS JIT build in production
-
-**Resolved 2026-08-19:** all pages now link a 32KB compiled, purged `docs/css/tailwind.css` built with the Tailwind CLI (issues #15, #17-#20).
-
-### 5. Google Fonts loaded render-blocking
-
-Font `<link>` tags are render-blocking. Using `media="print" onload="this.media='all'"` or `font-display: optional` would improve Largest Contentful Paint (LCP).
-
-### 6. Fixed grain overlay at z-50
-
-A full-viewport `<div>` with `z-50` is rendered permanently for a noise texture effect. While `pointer-events-none` prevents interaction issues, it forces a compositing layer on every frame.
+GitHub Pages serves `docs/` from `master` at
+`https://centercoopmedia.github.io/njblackpress/`. A merge can publish the site
+without a separate deploy command.

--- a/CODEBASE_OVERVIEW.md
+++ b/CODEBASE_OVERVIEW.md
@@ -17,7 +17,7 @@ Pages serves the committed results from `docs/`.
 | Archive | `docs/archive.html` | Publications |
 | Publication detail | `docs/publication.html?id=` | Publications, evidence, and recent stories |
 | Stories | `docs/story.html?id=` | Stories, events, and publications |
-| Eras | `docs/era.html?id=` | Events, stories, and publications |
+| Eras | `docs/era.html?decade=` | Events, stories, and publications |
 | Map | `docs/map.html` | Generated map publication data |
 | Woven | `docs/woven.html` | Publications, stories, events, and evidence |
 | Public wiki | `docs/wiki/` | Pre-rendered publication and browse pages |
@@ -56,18 +56,22 @@ Custom styles live in:
 ## Data flow
 
 ```text
-Notion CSV
-  -> data/convert_csv.py
-  -> data/publications.json
-
-Research batches
-  -> data/merge_research.py
+Current publication record
   -> data/publications.json
 
 Source catalog + rights manifest
   -> data/add_evidence.py
   -> data/publications.json
   -> docs/data/publications.json
+
+Hand-curated featured records
+  -> data/featured-publications.json
+  -> explicit copy and comparison
+  -> docs/data/featured-publications.json
+
+Rights manifest + local evidence corpus
+  -> data/make_clippings.py
+  -> docs/data/clippings.json and docs/images/evidence/
 
 Editorial events and stories
   -> data/build_site_events_stories.py
@@ -89,6 +93,10 @@ Publication data
 The `data/` copies are pipeline data. The `docs/data/` copies are browser data.
 Builders keep the paired files equal.
 
+`data/convert_csv.py` is for a controlled full refresh from a new Notion CSV.
+The checked-in CSV does not reproduce the current curated publication record.
+Do not use the converter for a routine correction.
+
 ## Generated boundaries
 
 Do not hand-edit compiled CSS, browser data copies, or generated wiki files.
@@ -97,6 +105,10 @@ Change the source and run its builder.
 The public HTML wiki generator removes and rebuilds `docs/wiki/`. The open
 knowledge format generator removes and rebuilds `okf/`. Review the full
 generated diff before commit.
+
+The clipping builder rewrites the clipping index but does not remove every old
+image. A rights downgrade must also remove any public image that the new index
+does not list.
 
 ## Validation model
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,100 @@
+# Contributing
+
+Thank you for helping improve the NJ Black Press Archive.
+
+## Report a correction
+
+Use the repository's data correction issue form for a missing or incorrect
+publication fact. Include:
+
+- The publication name and record URL.
+- The exact field that needs a change.
+- The proposed value.
+- A reliable source link or full citation.
+- Any rights or access limits on supporting files.
+
+Do not upload copyrighted newspaper pages unless you have permission to share
+them.
+
+## Development setup
+
+Install Node.js, npm, and Python 3. Then run:
+
+```bash
+npm ci
+npm run build:css
+cd docs
+python3 -m http.server 8000
+```
+
+Open `http://localhost:8000/`.
+
+## Choose the correct source
+
+| Change | Source |
+|---|---|
+| Shared page content | HTML under `docs/` |
+| Shared navigation | `docs/js/site-nav.js` |
+| Publication fields | `data/publications.csv` or the applicable research source |
+| Publication evidence | `data/research/source-catalog.json` |
+| Evidence rights | `data/research/rights/rights-manifest.json` |
+| Events and stories | `data/research/editorial/` |
+| Map locations | `data/municipality-centers.json` |
+| Tailwind styles | `src/input.css`, HTML classes, or JavaScript class strings |
+| Public wiki | `scripts/generate_html_wiki.py` and its source data |
+| Portable wiki | `scripts/generate_okf_wiki.py` and its source data |
+
+Read [data/DATA_DICTIONARY.md](data/DATA_DICTIONARY.md) before you change data
+shapes. Do not hand-edit generated files.
+
+## Build generated outputs
+
+Run only the builders needed for the change:
+
+```bash
+cd data
+python3 convert_csv.py
+python3 merge_research.py
+python3 add_evidence.py
+cd ..
+python3 data/build_site_events_stories.py
+python3 data/build_map_data.py
+python3 scripts/generate_html_wiki.py --base-url https://centercoopmedia.github.io/njblackpress/
+python3 scripts/generate_okf_wiki.py
+```
+
+Commit the source and its generated outputs together.
+
+## Validate the change
+
+Use the smallest checks that cover the changed area:
+
+| Area | Checks |
+|---|---|
+| Shared styles | `npm run build:css` and browser checks |
+| Publications and evidence | `python3 data/test_evidence.py` and `python3 data/test_source_catalog.py`, with the local evidence corpus |
+| Events and stories | `python3 data/test_site_data.py` |
+| Map | `python3 data/test_map.py` |
+| Navigation | `python3 data/test_navigation.py` |
+| Public wiki | `python3 data/test_wiki_publications.py` |
+| Portable wiki | `python3 scripts/generate_okf_wiki.py --check` |
+| Woven | `python3 data/test_woven_layout.py` and `python3 data/test_woven_usability.py` |
+
+Check visible changes in a browser at desktop and mobile sizes. Check keyboard
+navigation when the change affects controls, dialogs, or focus.
+
+Git ignores most large research files. Evidence checks need the separate local
+evidence corpus and will fail in a normal clone without it.
+
+## Pull request process
+
+1. Branch from the latest `master` branch.
+2. Make one focused change.
+3. Update source and generated files together.
+4. Run the applicable checks.
+5. Complete the pull request template.
+6. Address review comments and resolve their conversations.
+7. Wait for approval before merge.
+
+GitHub Pages publishes changes under `docs/` after merge. Verify the live route
+after publication.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,9 @@ Open `http://localhost:8000/`.
 |---|---|
 | Shared page content | HTML under `docs/` |
 | Shared navigation | `docs/js/site-nav.js` |
-| Publication fields | `data/publications.csv` or the applicable research source |
+| Publication fields | `data/publications.json` or the applicable research source |
+| Controlled full refresh | A fresh `data/publications.csv` Notion export |
+| Featured records | `data/featured-publications.json` |
 | Publication evidence | `data/research/source-catalog.json` |
 | Evidence rights | `data/research/rights/rights-manifest.json` |
 | Events and stories | `data/research/editorial/` |
@@ -52,11 +54,9 @@ shapes. Do not hand-edit generated files.
 Run only the builders needed for the change:
 
 ```bash
-cd data
-python3 convert_csv.py
-python3 merge_research.py
-python3 add_evidence.py
-cd ..
+python3 data/add_evidence.py
+cp data/featured-publications.json docs/data/featured-publications.json
+cmp data/featured-publications.json docs/data/featured-publications.json
 python3 data/build_site_events_stories.py
 python3 data/build_map_data.py
 python3 scripts/generate_html_wiki.py --base-url https://centercoopmedia.github.io/njblackpress/
@@ -64,6 +64,21 @@ python3 scripts/generate_okf_wiki.py
 ```
 
 Commit the source and its generated outputs together.
+
+The checked-in CSV is stale relative to the current publication record. Do not
+run `data/convert_csv.py` for a routine correction. Use it only after you add a
+fresh Notion export. Review the full dataset diff for lost enrichment, changed
+IDs, changed cessation years, changed active status, and an unexpected count.
+
+For a routine publication correction, edit `data/publications.json` and run
+`data/add_evidence.py`. For a featured-record change, copy its source to the
+browser data path and use `cmp` to prove that both files match.
+
+For a rights change, use a checkout with the full evidence corpus. Record each
+affected clipping output, run `python3 data/make_clippings.py`, and remove any
+old file under `docs/images/evidence/` that the new clipping index does not
+list. Confirm that downgraded source paths are absent from
+`docs/data/clippings.json` and that their old public files no longer exist.
 
 ## Validate the change
 

--- a/README.md
+++ b/README.md
@@ -88,9 +88,12 @@ Important generated files include:
 
 - `docs/css/tailwind.css`
 - `docs/data/publications.json`
+- `docs/data/featured-publications.json`
 - `docs/data/events.json`
 - `docs/data/stories.json`
 - `docs/data/map-publications.json`
+- `docs/data/clippings.json`
+- `docs/images/evidence/`
 - `docs/wiki/`
 - `okf/`
 
@@ -102,11 +105,9 @@ unless its rights status permits that use.
 Use the documented builder for each generated surface:
 
 ```bash
-cd data
-python3 convert_csv.py
-python3 merge_research.py
-python3 add_evidence.py
-cd ..
+python3 data/add_evidence.py
+cp data/featured-publications.json docs/data/featured-publications.json
+cmp data/featured-publications.json docs/data/featured-publications.json
 python3 data/build_site_events_stories.py
 python3 data/build_map_data.py
 python3 scripts/generate_html_wiki.py --base-url https://centercoopmedia.github.io/njblackpress/
@@ -115,6 +116,10 @@ python3 scripts/generate_okf_wiki.py
 
 Run only the builders needed for the changed source. Review generated diffs
 before you commit them.
+
+The checked-in CSV is not a safe input for a routine publication change. Do
+not run `data/convert_csv.py` unless you have a fresh Notion export and will
+review the full dataset diff for lost editorial enrichment.
 
 ## Validation
 

--- a/README.md
+++ b/README.md
@@ -1,171 +1,151 @@
 # NJ Black Press Archive
 
-<img width="1549" height="680" alt="image" src="https://github.com/user-attachments/assets/6a8dcb8d-192f-44f6-9043-cddd5f8219c0" />
+Historical archive of Black-owned and Black-focused publications in New Jersey
+from 1880 to the present.
 
-**[→ View the live archive](https://centercoopmedia.github.io/njblackpress/)**
+[View the live archive](https://centercoopmedia.github.io/njblackpress/)
 
-A historical database documenting Black publications in New Jersey from 1880 to present day. Built and maintained by the [Center for Cooperative Media](https://centerforcooperativemedia.org/) at Montclair State University.
+![NJ Black Press Archive](docs/og-image.png)
 
-## Overview
+The [Center for Cooperative Media](https://centerforcooperativemedia.org/) at
+Montclair State University maintains the archive. The current dataset contains
+more than 130 newspapers, magazines, newsletters, journals, and digital
+publications.
 
-The database catalogs 137 Black-owned and Black-focused publications that have operated in New Jersey — newspapers, magazines, newsletters, and digital outlets. The data spans 145 years of Black press history across 45+ cities statewide.
+## Explore the archive
 
-**Project lead:** Cassandra Etienne, Associate Director of Programming and Membership
-**Data curator:** Amanda Alicea
-**Project owner:** [Center for Cooperative Media](https://centerforcooperativemedia.org/)
+| Section | Purpose |
+|---|---|
+| [Home](https://centercoopmedia.github.io/njblackpress/) | Featured publications, archive introduction, timeline, and search |
+| [Archive](https://centercoopmedia.github.io/njblackpress/archive.html) | Filterable and sortable publication directory |
+| [Stories](https://centercoopmedia.github.io/njblackpress/story.html) | Sourced narratives that connect publications and events |
+| [Eras](https://centercoopmedia.github.io/njblackpress/era.html) | Historical periods and their publication activity |
+| [Map](https://centercoopmedia.github.io/njblackpress/map.html) | Publication activity by place and decade |
+| [Woven](https://centercoopmedia.github.io/njblackpress/woven.html) | Interactive loom view of the full publication timeline |
+| [Wiki](https://centercoopmedia.github.io/njblackpress/wiki/) | Pre-rendered publication and browse pages |
 
-## The website
+Each publication record includes known dates, locations, publishers, formats,
+archive links, historical notes, and supporting evidence when available.
 
-The archive is a static site deployed via GitHub Pages from the `/docs` directory. It includes:
+## Technology
 
-- **Home** (`/`) — featured historic and contemporary publications, decade timeline, and search preview
-- **Archive** (`/archive.html`) — full directory with filtering by city, decade, format, and status
-- **Publication** (`/publication.html?id=N`) — individual record pages with full historical detail
+- Static HTML, CSS, and JavaScript
+- Tailwind CSS 3, compiled into `docs/css/tailwind.css`
+- Python data builders, generators, and checks
+- Vendored Three.js modules for Woven
+- GitHub Pages from `master` and the `docs/` directory
 
-No build step. Vanilla JavaScript, Tailwind CSS via CDN.
+The project has no backend service, database server, or JavaScript framework.
 
-## Data structure
+## Repository map
 
-### Source files
-
-| Path | Contents |
-|------|----------|
-| `data/publications.csv` | Primary dataset (exported from Notion) |
-| `data/publications.json` | Generated JSON (used by the site) |
-| `data/featured-publications.json` | Curated records with richer detail |
-| `data/convert_csv.py` | CSV → JSON converter |
-| `data/merge_research.py` | Merges research findings into JSON |
-| `docs/data/` | Deployed copies of the above JSON files |
-
-### Publication record schema
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `id` | int | Unique identifier |
-| `name` | string | Publication name |
-| `alternateName` | string\|null | Other names used |
-| `city` | string\|null | Primary city of operation |
-| `publishers` | string\|null | Publishing entity or individuals |
-| `yearFounded` | int\|null | Start year |
-| `yearCeased` | int\|null | End year (null if still active) |
-| `frequency` | string\|null | Weekly, monthly, daily, etc. |
-| `format` | string\|null | Newspaper, periodical, digital |
-| `languages` | string | Primary language(s), defaults to "English" |
-| `archiveUrl` | string\|null | Library of Congress, WorldCat, Internet Archive links |
-| `websiteUrl` | string\|null | Current website URL |
-| `targetAudience` | string\|null | Intended readership |
-| `primaryFocus` | string\|null | Subject matter coverage |
-| `medium` | string | "Print", "Digital", or "Print/Digital" |
-| `missionStatement` | string\|null | Editorial philosophy |
-| `keyStaff` | string\|null | Notable editors/publishers |
-| `historicalNotes` | string\|null | Context and significance |
-| `isActive` | bool | Whether the publication is still operating |
-| `decade` | string | Decade of founding (e.g. "1880s") |
-
-### Data pipeline
-
-```
-Notion → data/publications.csv
-              ↓
-         convert_csv.py  →  data/publications.json
-              ↓
-         merge_research.py (enriches from data/research/*.json)
-              ↓
-         Copy to docs/data/ (manual step)
+```text
+docs/                         Published GitHub Pages site
+  data/                       Browser-ready data copies
+  js/                         Site scripts and Woven modules
+  wiki/                       Generated public HTML wiki
+data/                         Source data, research, builders, and checks
+  research/source-catalog.json
+  research/rights/rights-manifest.json
+okf/                          Generated portable markdown wiki
+scripts/                      HTML and open knowledge format generators
+src/input.css                 Tailwind input stylesheet
+tailwind.config.js            Tailwind content paths and design tokens
 ```
 
-## Notable publications
+Read [CODEBASE_OVERVIEW.md](CODEBASE_OVERVIEW.md) for the architecture and
+[data/DATA_DICTIONARY.md](data/DATA_DICTIONARY.md) for the data contracts.
 
-### Historical (pre-1950)
-- **The Sentinel** (1880, Trenton) — one of NJ's earliest Black newspapers
-- **New Jersey Trumpet** (1887–1897, Jersey City / Newark)
-- **The Echo** (1904–1943, Long Branch/Red Bank) — "Oldest colored paper in New Jersey"
-- **NJ Afro-American** (1941–present, Newark) — the longest-running Black newspaper in NJ
+## Local development
 
-### Civil rights era (1950–1980)
-- **Black Newark** (1968–1974) — published by the Committee for Unified Newark following the 1967 uprising
-- **Unity and Struggle** (1972, Newark) — connected to the Congress of Afrikan People
+Requirements:
 
-### Contemporary digital outlets (2010s–present)
-- **Black In Jersey** (2021, Trenton) — "Our Voices, Our Perspectives"
-- **NJ Urban News** (2018, Newark) — "A Voice for the Voiceless"
-- **Trenton Journal** (2021) — solutions-based journalism
-- **Ark Republic** (2017, Newark) — multimedia journalism
+- Node.js and npm
+- Python 3
 
-## Geographic coverage
+Install the locked Tailwind dependency and build the stylesheet:
 
-Publications span all regions of New Jersey:
-- **North Jersey:** Newark, Paterson, East Orange, Teaneck, Montclair, Jersey City
-- **Central Jersey:** Trenton, Princeton, Plainfield, Somerset, New Brunswick
-- **South Jersey:** Camden, Atlantic City, Swedesboro, Pleasantville
-
-## Working with the data
-
-The full dataset is available as JSON at:
-```
-https://centercoopmedia.github.io/njblackpress/data/publications.json
-```
-
-To regenerate from source:
 ```bash
-cd data/
-python3 convert_csv.py          # Regenerate publications.json from CSV
-python3 merge_research.py       # Merge research findings
-cp publications.json ../docs/data/publications.json
+npm ci
+npm run build:css
 ```
 
-External archives referenced in the data:
-- [Library of Congress](https://loc.gov)
-- [WorldCat](https://search.worldcat.org)
-- [Internet Archive](https://archive.org)
+Serve the published directory:
+
+```bash
+cd docs
+python3 -m http.server 8000
+```
+
+Open `http://localhost:8000/`.
+
+## Data and generated files
+
+The repository keeps pipeline data under `data/` and browser copies under
+`docs/data/`. Do not edit a browser copy without updating its source.
+
+Important generated files include:
+
+- `docs/css/tailwind.css`
+- `docs/data/publications.json`
+- `docs/data/events.json`
+- `docs/data/stories.json`
+- `docs/data/map-publications.json`
+- `docs/wiki/`
+- `okf/`
+
+Publication evidence comes from
+`data/research/source-catalog.json`. Publication rights decisions come from
+`data/research/rights/rights-manifest.json`. Do not publish an evidence file
+unless its rights status permits that use.
+
+Use the documented builder for each generated surface:
+
+```bash
+cd data
+python3 convert_csv.py
+python3 merge_research.py
+python3 add_evidence.py
+cd ..
+python3 data/build_site_events_stories.py
+python3 data/build_map_data.py
+python3 scripts/generate_html_wiki.py --base-url https://centercoopmedia.github.io/njblackpress/
+python3 scripts/generate_okf_wiki.py
+```
+
+Run only the builders needed for the changed source. Review generated diffs
+before you commit them.
+
+## Validation
+
+Run the checks that match the changed area. Common checks include:
+
+```bash
+npm run build:css
+python3 data/test_site_data.py
+python3 data/test_source_catalog.py
+python3 data/test_map.py
+python3 data/test_navigation.py
+python3 data/test_wiki_publications.py
+python3 data/test_woven_layout.py
+python3 data/test_woven_usability.py
+python3 scripts/generate_okf_wiki.py --check
+```
+
+The evidence and source-catalog checks require the local evidence corpus under
+`data/research/`. Git ignores most of those large research files. Run those
+checks only in a checkout that has the corpus.
+
+Visible changes also need browser checks at desktop and mobile sizes.
 
 ## Contributing
 
-If you have information about NJ Black publications not in the database, or corrections to existing records, open an issue or submit a pull request.
+Read [CONTRIBUTING.md](CONTRIBUTING.md) before you change data or generated
+files. Use the data correction issue form when you have a source for a missing
+or incorrect fact.
 
-## License
+## Citation and reuse
 
-This dataset is made available for research and educational purposes. Please cite the Center for Cooperative Media when using this data.
-
-## The wiki
-
-The archive is also published as a cross-linked wiki, in two forms generated
-from the same `data/publications.json` source.
-
-### Public HTML wiki (`/wiki/`)
-
-A browsable, pre-rendered HTML wiki lives in `docs/wiki/` and ships with the
-site at **[`/njblackpress/wiki/`](https://centercoopmedia.github.io/njblackpress/wiki/)**
-(linked from the main nav). It matches the site's look (ink/paper/accent
-palette, Fraunces + DM Sans) and gives every record a crawlable permalink:
-
-- `wiki/index.html` — landing page with snapshot stats and browse links
-- `wiki/publications.html` — sortable index of all records (city, years, status)
-- `wiki/statistics.html` — counts, a founding-decade timeline, top cities, longest-running titles
-- `wiki/featured.html` — curated historic and contemporary publications
-- `wiki/publications/` — one page per publication, cross-linked to related records
-- `wiki/cities/`, `wiki/decades/`, `wiki/formats/`, `wiki/mediums/` — browse-by pages
-- `wiki/sitemap.xml` — sitemap covering every wiki page (referenced from `robots.txt`)
-
-Regenerate it after updating the data:
-
-```bash
-python3 scripts/generate_html_wiki.py
-```
-
-### Open knowledge format wiki (`okf/`)
-
-A portable [open knowledge format](https://cloud.google.com/blog/products/ai-machine-learning/introducing-the-open-knowledge-format)
-bundle in `okf/` — a directory of markdown files with YAML frontmatter and
-standard links, so people and agents can read the archive without running the
-site JavaScript. The bundle contains 250 markdown files (137 publication pages,
-grouped browse pages for cities/decades/formats/mediums, plus index, overview,
-statistics, featured, data-model, and change-log pages).
-
-```bash
-python3 scripts/generate_okf_wiki.py          # regenerate
-python3 scripts/generate_okf_wiki.py --check  # validate counts and frontmatter
-```
-
-Both generators accept `--generated-at YYYY-MM-DD` for reproducible timestamps,
-and share their data-shaping helpers so the HTML and markdown stay in lockstep.
+Credit the Center for Cooperative Media when you use archive data. This
+repository does not currently include a software or data license file. Contact
+the Center before you redistribute the dataset or evidence files.


### PR DESCRIPTION
## Summary

- refresh the README, contributor guide, agent instructions, and codebase overview for the current archive
- document the live GitHub Pages routes, generated-file boundaries, data pipeline, rights rules, and focused checks
- add focused pull request, bug report, and data correction templates

## Stack

- Parent: #62
- Base: `ux/woven-guided-entry`
- Merge #62 before this pull request.

## Verification

- `npm ci`
- `npm run build:css`
- `python3 data/test_site_data.py`
- `python3 data/test_map.py`
- `python3 data/test_navigation.py`
- `python3 data/test_wiki_publications.py`
- `python3 data/test_woven_layout.py`
- `python3 data/test_woven_usability.py`
- `python3 scripts/generate_okf_wiki.py --check`
- GitHub issue template YAML parsing
- documented path checks
- documentation anti-slop check
- `git diff --check`
- local cross-model review gate: passed with no findings

`data/test_evidence.py` and `data/test_source_catalog.py` require the ignored local evidence corpus. The corpus is not present in this worktree, so those two checks cannot complete here.

## Deployment

This pull request changes repository guides and GitHub templates only. It does not change the published `docs/` site.
